### PR TITLE
Add security audit dependencies & fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.  They are
+# provided by a third-party and are governed by separate terms of service,
+# privacy policy, and support documentation.
+#
+# This workflow will install a prebuilt Ruby version, install dependencies, and
+# run tests and linters.
+name: "Ruby on Rails CI"
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: sif
+          POSTGRES_USER: sif
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://sif:password@localhost:5432/sif"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+    
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1.152.0 
+        with:
+         ruby-version: '3.2.2'
+         bundler-cache: true
+     
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+    
+      - name: Run tests
+        run: bin/rake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@
 name: "Ruby on Rails CI"
 on:
   push:
-    branches: [ "*" ]
+    branches: [ 'main' ]
   pull_request:
-    branches: [ "*" ]
+    types: ['opened', 'reopened', 'synchronize', 'unlocked']
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,30 @@
+name: Ensure Docker container for Ruby can build successfully 
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize', 'unlocked']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Images
+        working-directory: ./
+        run: |
+           docker compose build
+           
+      - name: Run containers 
+        working-directory: ./
+        run: |
+          docker compose up -d
+  
+      - name: Curl web page 
+        working-directory: ./
+        run: |
+          curl -X GET http://localhost:3000

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: "Lint"
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1.152.0  
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+    
+      # - name: Add vendor directory to path 
+      #   run:  echo "$GITHUB_WORKSPACE/vendor/bundle/ruby/3.2.0/bin" >> $GITHUB_PATH 
+      
+      - name: Security audit dependencies
+        run: bundle exec bundler-audit check --update 
+
+      - name: Security audit application code
+        run: bundle exec brakeman -q -w2
+
+      - name: Lint Ruby files
+        run: bundle exec rubocop --parallel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
 name: "Lint"
 on:
   push:
-    branches: [ "*" ]
+    branches: [ 'main' ]
   pull_request:
-    branches: [ "*" ]
+    types: ['opened', 'reopened', 'synchronize', 'unlocked']
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
           bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
 
       - name: Lint Ruby files
-        run: bundle exec standardrb
+        run: bundle exec standardrb * 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
           bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
 
       - name: Lint Ruby files
-        run: bundle exec standardrb * 
+        run: bundle exec standardrb 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,15 +14,6 @@ jobs:
         with:
           ruby-version: '3.2.2'
           bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
-    
-      # - name: Add vendor directory to path 
-      #   run:  echo "$GITHUB_WORKSPACE/vendor/bundle/ruby/3.2.0/bin" >> $GITHUB_PATH 
-      
-      - name: Security audit dependencies
-        run: bundle exec bundler-audit check --update 
-
-      - name: Security audit application code
-        run: bundle exec brakeman -q -w2
 
       - name: Lint Ruby files
-        run: bundle exec rubocop --parallel
+        run: bundle exec standardrb

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,23 @@
+name: "Security"
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize', 'unlocked']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1.152.0  
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+    
+      - name: Security audit dependencies
+        run: bundle exec bundler-audit check --update 
+
+      - name: Security audit application code
+        run: bundle exec brakeman -q -w2
+

--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,8 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Patch-level verification for Bundler 
-gem  "bundler-audit"
+# Patch-level verification for Bundler
+gem "bundler-audit"
 
 # Dockerize a rails app for production
 gem "dockerfile-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,7 @@ PLATFORMS
   aarch64-linux
   x86_64-darwin-21
   x86_64-linux
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
This PR is a small part of #10.  It adds rubocop and rubocop-rspec for linting. 

See here for a test run: https://github.com/rubyforgood/stocks-in-the-future/actions/runs/5703792402/job/15456771850

@cflipse does not want this enforced so it lives in a separate workfow. 

<!-- Go through this checklist before opening your PR

### Self Checklist:

 X I have performed a self-review of my own code
 X I have commented my code, particularly in hard-to-understand areas
 X I have made corresponding changes to the documentation
 X  I have added tests that prove my fix is effective or that my feature works
 X New and existing unit tests pass locally with my changes
 X  have run [`standardrb`](https://github.com/testdouble/standard) and verified there are no lint offenses in my code (use `standardrb --fix` to autocorrect offenses)
X I have included "WIP" in the PR Title if this is in progress

