### PR TITLE
Add rails db:setup step to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ application up and running.
 
 Things you may want to cover:
 
-* Ruby version
+- Ruby version
 
-* System dependencies
+- System dependencies
 
-* Configuration
-
+- Configuration
 
 ## Running in docker
 
@@ -20,12 +19,14 @@ locally, with preconfigured connections.
 
 At present, these services are: postgres, redis, and the rails application.
 
-To start the application, run `docker compose up`.  Adding `-d` will free your
-terminal after the service boots.  After the application starts, the site can
+To start the application, run `docker compose up`. Adding `-d` will free your
+terminal after the service boots. After the application starts, the site can
 be accessed at `http://localhost:3000`.
 
+To set up the database the first time run, `docker compose run --rm stocks bin/rails db:setup`
+
 The docker entrypoint takes care of installing updated gems, and running any
-pending database migrations before starting the rails application.  Any
+pending database migrations before starting the rails application. Any
 gem or configuration changes can be applied by restarting the application server:
 `docker compose restart stocks`
 
@@ -46,12 +47,13 @@ $ docker compose run --rm stocks bash
  ⠿ Container stocks-in-the-future-db-1     Running                                                  0.0s
  ⠿ Container stocks-in-the-future-redis-1  Running                                                  0.0s
 The Gemfile's dependencies are satisfied
-root@cea35fe15a85:/rails# 
+root@cea35fe15a85:/rails#
 ```
 
 ### Running tests
 
 To run RSpec tests in the container:
+
 ```shell
 docker compose run --rm stocks rspec
 ```


### PR DESCRIPTION
Adds the db:setup command to the readme for people new to the project. 