### PR TITLE
Basic developer tooling for running the app in Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,13 +12,13 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
     build-essential libpq-dev curl \
     nodejs npm
+RUN npm install -g yarn
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 COPY package.json yarn.lock ./
-RUN npm install -g yarn
-RUN yarn install
+RUN yarn
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=3.2.3
+FROM ruby:$RUBY_VERSION-slim as base
+
+# Rails app lives here
+WORKDIR /rails
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    build-essential libpq-dev curl \
+    nodejs npm
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY package.json yarn.lock ./
+RUN npm install -g yarn
+RUN yarn install
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD ["./bin/rails", "console"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 * A ruby version manager such as [rvm](https://rvm.io/rvm/install) or [rbenv](https://formulae.brew.sh/formula/rbenv)
 * Ruby 3.2.3 (Installed via ruby manager ^)
 * [PostgreSQL](https://www.postgresql.org/), if you're not using Docker.
+* [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and yarn (`npm install -g yarn`)
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,36 @@
 
 * A ruby version manager such as [rvm](https://rvm.io/rvm/install) or [rbenv](https://formulae.brew.sh/formula/rbenv)
 * Ruby 3.2.3 (Installed via ruby manager ^)
-* [Rails 7](https://guides.rubyonrails.org/)
-* [PostgreSQL](https://www.postgresql.org/)
-* [bun](https://bun.sh/docs/installation)
+* [PostgreSQL](https://www.postgresql.org/), if you're not using Docker.
 
 # Installation
 
-## Mac Users
+## With Docker
+
+Build and start the application with `docker compose up`. Once the application has successfully started, you should be able to visit it at http://localhost:3000/
+
+Run commands in docker with the `bin/dc` helper script on macos or Linux.
+
+```console
+$ bin/dc rails db:setup
+$ bin/dc rails test
+```
+
+Or by prefacing `rails` commands with `docker compose run stocks`.
+
+```console
+$ docker compose run stocks rails db:setup
+$ docker compose run stocks rails test
+```
+
+## Mac & Linux Users
 
 * Run setup: `bin/setup`
-* Run the Rails server locally: `foreman start -f Procfile.dev`
+* Run the Rails server locally: `bin/dev`
 
-## Windows & Linux users
+## Windows
 
-It is **strongly** recommend to use Docker.
+It is **strongly** recommend to use Docker. See instructions above.
 
 ## URL
 

--- a/bin/dc
+++ b/bin/dc
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# if first argument is help or -h or --help, show help
+if [ "$1" = "help" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 [command]"
+  echo "  command: command to run in the stocks container"
+  echo
+  echo "Examples:"
+  echo "  bin/dc rails db:migrate                        # run migrations"
+  echo "  bin/dc rails test                              # run tests"
+  echo "  bin/dc rails console                           # start Rails console"
+  echo "  bin/dc rails generate model Boop name:string   # generate a Rails model"
+  exit 0
+fi
+
+echo "\033[2m> docker compose run stocks $@\033[0m"
+docker compose run --rm --no-deps stocks $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+---
+version: "3.9"
+services:
+  redis:
+    image: redis:7.0
+    ports:
+      - 6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+    volumes:
+      - redis:/data
+
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      PGUSER: sif
+      POSTGRES_USER: sif
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: sif
+    ports:
+      - 5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "--database", "stocks_in_the_future_development" ]
+      interval: 10s
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+  stocks:
+    build:
+      dockerfile: Dockerfile.dev
+      context: .
+    image: stocks:dev
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${APP_PORT:-3000}"]
+    command: "bin/docker-entrypoint bin/rails server -b 0.0.0.0 -p ${APP_PORT:-3000}"
+    entrypoint: bin/docker-entrypoint
+    ports:
+      - "${APP_PORT:-3000}:${APP_PORT:-3000}"
+    volumes:
+      - .:/rails
+      - bundler:/usr/local/bundle
+      - node_modules:/rails/node_modules
+    environment:
+      RAILS_ENV: development
+      DATABASE_URL: postgresql://sif:password@db/
+      BROWSERSLIST_IGNORE_OLD_DATA: true
+
+  stocks-js:
+    image: stocks:dev
+    working_dir: /rails
+    tty: true
+    command: sh -c "yarn install && yarn build --watch"
+    volumes:
+      - .:/rails
+      - node_modules:/rails/node_modules
+
+  stocks-css:
+    image: stocks:dev
+    environment:
+      BROWSERSLIST_IGNORE_OLD_DATA: true
+    working_dir: /rails
+    tty: true
+    command: sh -c "yarn install && yarn build:css --watch=forever"
+    volumes:
+      - .:/rails
+      - node_modules:/rails/node_modules
+
+volumes:
+  redis:
+  postgres:
+  bundler:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       BROWSERSLIST_IGNORE_OLD_DATA: true
 
   stocks-js:
-    image: stocks:dev
+    image: node:lts-alpine
     working_dir: /rails
     tty: true
     command: sh -c "yarn install && yarn build --watch"
@@ -61,7 +61,7 @@ services:
       - node_modules:/rails/node_modules
 
   stocks-css:
-    image: stocks:dev
+    image: node:lts-alpine
     environment:
       BROWSERSLIST_IGNORE_OLD_DATA: true
     working_dir: /rails


### PR DESCRIPTION
A proposed docker-compose.yml file for running and developing the app in docker and some supporting documentation and simple tooling to use it. 

## Decisions

### install yarn with `npm install -g yarn`

In `Dockerfile.dev`, use `npm install -g yarn` to get yarn instead of Yarn's `corepack` recommendation. This lets us not have to reinstall corepack and yarn every time we run a command like `docker compose run stocks rails test`.

```dockerfile
# Install packages needed to build gems
RUN apt-get update -qq && \
    apt-get install --no-install-recommends -y \
    build-essential libpq-dev curl \
    nodejs npm
RUN npm install -g yarn

COPY Gemfile Gemfile.lock ./
RUN bundle install

COPY package.json yarn.lock ./
RUN yarn
```

### use `node:lts-alpine` as the image for stocks-js and stocks-css services

It might be possible to reuse the `stocks` service image to build assets, but `node:lts-alpine` has yarn preinstalled, so there's very little fiddling required to make the services work with `docker compose up`.