### PR TITLE
Ruby test and lint github action workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+---
+name: "Continuous Integration"
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize', 'unlocked']
+
+jobs:
+  ruby-lint:
+    name: Ruby Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.178.0
+        with:
+          ruby-version: '3.2.3'
+          bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+
+      - name: Ruby Lint
+        run: bundle exec standardrb --parallel -f github
+
+  rails-test:
+    name: Rails Test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: sif
+          POSTGRES_USER: sif
+          POSTGRES_PASSWORD: password
+      redis:
+        image: redis:7.0
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://sif:password@localhost:5432/sif"
+      REDIS_URL: "redis://localhost:6379/1"
+      BROWSERSLIST_IGNORE_OLD_DATA: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.178.0
+        with:
+          ruby-version: '3.2.3'
+          bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+
+      - name: Set up database
+        run: bin/rails db:setup
+
+      - name: Run tests
+        run: bin/rails test

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,5 @@
+parallel: true
+ruby_version: 3.2
+
+plugins:
+  - standard-rails

--- a/Gemfile
+++ b/Gemfile
@@ -23,12 +23,15 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]
+
+  # a linting tool, to encourage/enforce a consistent code style
+  gem "standardrb"
 end
 
 group :development do
   gem "bundler-audit"
   gem "pry", "~> 0.14.2"
-  gem "standardrb"
+  # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
 
   # a linting tool, to encourage/enforce a consistent code style
   gem "standardrb"
+  gem "standard-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,11 @@ GEM
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rails (2.23.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -316,6 +321,9 @@ GEM
     standard-performance (1.4.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.21.0)
+    standard-rails (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop-rails (~> 2.23.1)
     standardrb (1.0.1)
       standard
     stimulus-rails (1.3.3)
@@ -376,6 +384,7 @@ DEPENDENCIES
   selenium-webdriver
   shadcn-ui (~> 0.0.12)
   sprockets-rails
+  standard-rails
   standardrb
   stimulus-rails
   turbo-rails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: sif
     ports:
-      - 5432
+      - 5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "--database", "stocks_in_the_future_development" ]
       interval: 10s


### PR DESCRIPTION
This PR introduces a workflow for running the Rails test suite and [Ruby Standard](https://github.com/standardrb/standard) linter on pull requests for the project.

This workflow _works_ as currently written, but fails checks because we have test failures and linter violations.

Once those issues are fixed, we can add it as a branch protection in the project settings. 

