### PR TITLE
Add admin column to user and check for admin for access to admin pages

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -9,7 +9,7 @@ module Admin
     before_action :authenticate_admin
 
     def authenticate_admin
-      # TODO Add authentication logic here.
+      redirect_to root_path, alert: "You are not authorized to access this page." unless current_user&.admin?
     end
 
     # Override this value to specify the number of elements to display at a time

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <% if current_user&.admin? %>
+      <%= link_to "Admin Dashboard", admin_root_path %>
+    <% end %>
     <title>StocksInTheFuture</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>

--- a/db/migrate/20250418002328_add_admin_to_users.rb
+++ b/db/migrate/20250418002328_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_01_143331) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_18_002328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -131,6 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_01_143331) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "classroom_id"
+    t.boolean "admin", default: false
     t.index ["classroom_id"], name: "index_users_on_classroom_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true

--- a/test/controllers/admin/application_controller_test.rb
+++ b/test/controllers/admin/application_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Admin::ApplicationControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:admin)
+    @user = users(:one)
+  end
+
+  test "admin can access admin dashboard" do
+    sign_in(@admin)
+    get admin_root_path
+    assert_response :success
+  end
+
+  test "non-admin cannot access admin dashboard" do
+    sign_in(@user)
+    get admin_root_path
+    assert_redirected_to root_path
+    assert_equal "You are not authorized to access this page.", flash[:alert]
+  end
+end

--- a/test/controllers/admin/students_controller_test.rb
+++ b/test/controllers/admin/students_controller_test.rb
@@ -3,9 +3,11 @@ require 'test_helper'
 class Admin::StudentsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @student = users(:one)
+    @admin = users(:admin)
   end
 
   test 'should update student email' do
+    sign_in(@admin)
     @student.update_attribute(:email, 'nottest@nottest.com')
 
     patch admin_student_url(@student), params: { student: { email: 'test@test.com' } }
@@ -15,6 +17,7 @@ class Admin::StudentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not update with an error' do
+    sign_in(@admin)
     @student.update_attribute(:username, 'testingusername')
 
     patch admin_student_url(@student), params: { student: { username: '' } }
@@ -27,6 +30,7 @@ class Admin::StudentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'given a add_fund_amount, creates a transaction' do
+    sign_in(@admin)
     assert_difference('PortfolioTransaction.count', 1) do
       patch admin_student_url(@student), params: { student: { add_fund_amount: '10.50' } }
     end
@@ -41,6 +45,7 @@ class Admin::StudentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'given an empty add_fund_amount, does not create a transaction' do
+    sign_in(@admin)
     assert_difference('PortfolioTransaction.count', 0) do
       patch admin_student_url(@student), params: { student: { add_fund_amount: '' } }
     end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,11 +8,15 @@ one:
   username: abc123
   classroom: one
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  admin: false
 
-# column: value
-#
 two:
   username: def123
   classroom: two
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
-# column: value
+  admin: false
+admin:
+  username: admin
+  classroom: one
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  admin: true


### PR DESCRIPTION
Added an `admin` column to Users table and used that to add a check for admin flag in order for a user to access admin pages.