### PR TITLE
Change all references to stock price_info to price

### DIFF
--- a/app/dashboards/stock_dashboard.rb
+++ b/app/dashboards/stock_dashboard.rb
@@ -23,7 +23,7 @@ class StockDashboard < Administrate::BaseDashboard
     industry_avg_sales_growth: Field::String.with_options(searchable: false),
     management: Field::Text,
     portfolio_stocks: Field::HasMany,
-    price_info: Field::String.with_options(searchable: false),
+    price: Field::String.with_options(searchable: false),
     profit_margin: Field::String.with_options(searchable: false),
     sales_growth: Field::String.with_options(searchable: false),
     stock_exchange: Field::String,
@@ -62,7 +62,7 @@ class StockDashboard < Administrate::BaseDashboard
     industry_avg_sales_growth
     management
     portfolio_stocks
-    price_info
+    price
     profit_margin
     sales_growth
     stock_exchange
@@ -89,7 +89,7 @@ class StockDashboard < Administrate::BaseDashboard
     industry_avg_sales_growth
     management
     portfolio_stocks
-    price_info
+    price
     profit_margin
     sales_growth
     stock_exchange

--- a/app/views/portfolios/_stock_card.html.erb
+++ b/app/views/portfolios/_stock_card.html.erb
@@ -12,7 +12,7 @@
     <div class="text-right">
         <p class="font-medium">
             <!-- Current Price -->
-            <!-- will be calculated from `stock.price_info` -->
+            <!-- will be calculated from `stock.price` -->
             $120.00
         </p>
         <p class="text-sm text-gray-500 dark:text-gray-400">
@@ -25,7 +25,7 @@
             <!-- TODO: link to `Buy` transaction -->
             Buy
         </button>
-        
+
         <button class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">
             <!-- TODO: link to `Sell` transaction -->
             Sell

--- a/test/controllers/admin/stocks_controller_test.rb
+++ b/test/controllers/admin/stocks_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Admin::StocksControllerTest < ActionDispatch::IntegrationTest
+  test "new" do
+    sign_in(users(:admin))
+
+    get new_admin_stock_path
+
+    assert_response :success
+  end
+
+  test "create" do
+    params = { stock: { company_name: "Apple Inc." } }
+
+    sign_in(users(:admin))
+
+    assert_difference "Stock.count", 1 do
+      post(admin_stocks_path, params:)
+    end
+
+    assert_redirected_to admin_stock_path(Stock.last)
+    assert_equal "Stock was successfully created.", flash[:notice]
+  end
+end


### PR DESCRIPTION
Resolves #197

The `price_info` column was renamed to `price` in #156.