### PR TITLE
Test Year Model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 
 group :test do
   gem "capybara"
+  gem "factory_bot_rails"
   gem "selenium-webdriver"
   gem "webmock"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,11 @@ GEM
     docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.1)
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -400,6 +405,7 @@ DEPENDENCIES
   debug
   delayed_job_active_record
   devise (~> 4.9)
+  factory_bot_rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -1,5 +1,6 @@
 class Classroom < ApplicationRecord
   belongs_to :year
   belongs_to :school
-  has_many :users
+
+  has_many :users, dependent: :destroy
 end

--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -1,7 +1,8 @@
 class Portfolio < ApplicationRecord
   belongs_to :user
-  has_many :portfolio_transactions
-  has_many :portfolio_stocks
+
+  has_many :portfolio_transactions, dependent: :destroy
+  has_many :portfolio_stocks, dependent: :destroy
 
   def cash_balance
     portfolio_transactions.sum(:amount)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
-  has_one :portfolio
-  has_many :orders
   belongs_to :classroom
+
+  has_one :portfolio, dependent: :destroy
+  has_many :orders, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/year.rb
+++ b/app/models/year.rb
@@ -1,5 +1,6 @@
 class Year < ApplicationRecord
-  has_many :school_years
+  has_many :classrooms, dependent: :destroy
+  has_many :school_years, dependent: :destroy
   has_many :schools, through: :school_years
 
   validates :year, presence: true, uniqueness: true

--- a/db/migrate/20250427103023_add_not_null_constraint_to_year_on_years.rb
+++ b/db/migrate/20250427103023_add_not_null_constraint_to_year_on_years.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToYearOnYears < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :years, :year, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_18_002328) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_27_103023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -142,7 +142,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_18_002328) do
   end
 
   create_table "years", force: :cascade do |t|
-    t.integer "year"
+    t.integer "year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["year"], name: "index_years_on_year", unique: true

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :year do
+    year { 2000 }
+  end
+end

--- a/test/fixtures/classrooms.yml
+++ b/test/fixtures/classrooms.yml
@@ -2,12 +2,12 @@
 
 one:
   name: MyString
-  year: one
+  year: current
   school: one
   grade: MyString
 
 two:
   name: MyString
-  year: two
+  year: current
   school: two
   grade: MyString

--- a/test/fixtures/school_years.yml
+++ b/test/fixtures/school_years.yml
@@ -2,8 +2,8 @@
 
 one:
   school: one
-  year: one
+  year: current
 
 two:
   school: two
-  year: two
+  year: current

--- a/test/fixtures/years.yml
+++ b/test/fixtures/years.yml
@@ -1,7 +1,2 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  year: 2023
-
-two:
-  year: 2024
+current:
+  year: <%= Date.current.year %>

--- a/test/models/year_test.rb
+++ b/test/models/year_test.rb
@@ -1,7 +1,26 @@
 require "test_helper"
 
 class YearTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "factory" do
+    assert build(:year).validate!
+  end
+
+  test "destroy" do
+    assert years(:current).destroy!
+  end
+
+  test "year presence" do
+    year = build(:year, year: nil)
+
+    assert_not year.valid?
+    assert year.errors.added?(:year, :blank)
+  end
+
+  test "year uniqueness" do
+    taken_year_value = years(:current).year
+    year = build(:year, year: taken_year_value)
+
+    assert_not year.valid?
+    assert year.errors.added?(:year, :taken, value: taken_year_value)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ require "webmock/minitest"
 
 module ActiveSupport
   class TestCase
+    include FactoryBot::Syntax::Methods
+
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 


### PR DESCRIPTION
This PR:
- adds tests for the year model.
- makes the year column not nullable on the database level.
- uses realistic data for year fixture.
- adds the factory_bot_rails gem for factories.

### Fixtures and Factories
Fixtures are a great way to keep test setup simple and focused. They work especially well for establishing common baseline data that many tests can rely on.

However, fixtures shouldn't be used for every possible data permutation. Trying to model every variation with fixtures tends to make them bloated, hard to understand, and brittle. Similarly, mutating existing fixtures inside a test to fit a specific need is generally considered an anti-pattern that undermines the clarity and reliability that fixtures are supposed to provide.

Because of these trade-offs, I recommend a hybrid approach:
- Use fixtures for stable, shared baseline data that benefits multiple tests.
- Use factories when a test needs a custom or dynamic setup that doesn't cleanly fit into a shared fixture.

This way, we get the best of both worlds: fast, consistent tests where possible, and flexible, explicit setup when needed.