### PR TITLE
Bump administrate from 0.20.1 to 1.0.0.beta3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "3.2.3"
 
 gem "rails", "~> 7.2.2"
 
-gem "administrate", "~> 0.20.1"
+gem "administrate", "1.0.0.beta3"
 gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "daemons"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,14 +74,11 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    administrate (0.20.1)
-      actionpack (>= 6.0, < 8.0)
-      actionview (>= 6.0, < 8.0)
-      activerecord (>= 6.0, < 8.0)
-      jquery-rails (~> 4.6.0)
+    administrate (1.0.0.beta3)
+      actionpack (>= 6.0, < 9.0)
+      actionview (>= 6.0, < 9.0)
+      activerecord (>= 6.0, < 9.0)
       kaminari (~> 1.2.2)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
     ast (2.4.3)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -129,14 +126,14 @@ GEM
       responders
       warden (~> 1.2.3)
     docile (1.4.1)
-    drb (2.2.1)
+    drb (2.2.3)
+    erb (5.0.1)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
-    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.2)
@@ -150,10 +147,6 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.12.0)
@@ -184,7 +177,7 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
     net-imap (0.5.8)
@@ -223,7 +216,7 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (5.2.5)
+    psych (5.2.6)
       date
       stringio
     public_suffix (6.0.1)
@@ -254,7 +247,7 @@ GEM
       activesupport (= 7.2.2.1)
       bundler (>= 1.15.0)
       railties (= 7.2.2.1)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -271,7 +264,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.0)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.1)
@@ -306,16 +300,7 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     securerandom (0.4.1)
-    selectize-rails (0.12.6)
     selenium-webdriver (4.32.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -331,12 +316,13 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     sin_lru_redux (2.5.2)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.2)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     standard (1.49.0)
       language_server-protocol (~> 3.17.0.2)
@@ -361,7 +347,6 @@ GEM
     tailwind_merge (0.16.0)
       sin_lru_redux (~> 2.5)
     thor (1.3.2)
-    tilt (2.3.0)
     timeout (0.4.3)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
@@ -390,7 +375,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.2)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   aarch64-linux
@@ -401,7 +386,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  administrate (~> 0.20.1)
+  administrate (= 1.0.0.beta3)
   bootsnap
   bundler-audit
   capybara


### PR DESCRIPTION
Version 0.20.1 is incompatible with Rails 8.

Refs #225 


![Screenshot 2025-05-24 at 7 43 10 AM](https://github.com/user-attachments/assets/985a5ff1-15dd-4384-8b06-3967eb38f7ab)
