### PR TITLE
Update `Year` model to replace `year` attribute with `name`

### DIFF
--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -20,7 +20,7 @@ class ClassroomsController < ApplicationController
     @classroom = Classroom.new(classroom_params.except(:school_name, :year_value))
 
     school = School.find_or_create_by(name: classroom_params[:school_name])
-    year = Year.find_or_create_by(year: classroom_params[:year_value])
+    year = Year.find_or_create_by(name: classroom_params[:year_value])
     school_year = SchoolYear.find_or_create_by(school: school, year: year)
 
     @classroom.school_year = school_year
@@ -34,7 +34,7 @@ class ClassroomsController < ApplicationController
 
   def update
     school = School.find_or_create_by(name: classroom_params[:school_name])
-    year = Year.find_or_create_by(year: classroom_params[:year_value])
+    year = Year.find_or_create_by(name: classroom_params[:year_value])
     school_year = SchoolYear.find_or_create_by(school: school, year: year)
 
     @classroom.school_year = school_year

--- a/app/dashboards/year_dashboard.rb
+++ b/app/dashboards/year_dashboard.rb
@@ -11,7 +11,7 @@ class YearDashboard < Administrate::BaseDashboard
     id: Field::Number,
     school_years: Field::HasMany,
     schools: Field::HasMany,
-    year: Field::Number,
+    name: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -25,7 +25,7 @@ class YearDashboard < Administrate::BaseDashboard
     id
     school_years
     schools
-    year
+    name
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -34,7 +34,7 @@ class YearDashboard < Administrate::BaseDashboard
     id
     school_years
     schools
-    year
+    name
     created_at
     updated_at
   ].freeze
@@ -45,7 +45,7 @@ class YearDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     school_years
     schools
-    year
+    name
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/models/year.rb
+++ b/app/models/year.rb
@@ -3,5 +3,5 @@ class Year < ApplicationRecord
   has_many :schools, through: :school_years
   has_many :classrooms, through: :school_years
 
-  validates :year, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/views/classrooms/_classroom.html.erb
+++ b/app/views/classrooms/_classroom.html.erb
@@ -6,7 +6,7 @@
 
   <p class="my-5">
     <strong class="block font-medium mb-1">Year:</strong>
-    <%= classroom.school_year.year.year %>
+    <%= classroom.school_year.year.name %>
   </p>
 
   <p class="my-5">

--- a/db/migrate/20250526201022_change_year_column_to_name_and_update_type.rb
+++ b/db/migrate/20250526201022_change_year_column_to_name_and_update_type.rb
@@ -1,0 +1,11 @@
+class ChangeYearColumnToNameAndUpdateType < ActiveRecord::Migration[7.2]
+  def up
+    rename_column :years, :year, :name
+    change_column :years, :name, :string, null: false
+  end
+
+  def down
+    change_column :years, :name, :integer
+    rename_column :years, :name, :year
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_25_174026) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_26_201022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -141,10 +141,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_25_174026) do
   end
 
   create_table "years", force: :cascade do |t|
-    t.integer "year", null: false
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["year"], name: "index_years_on_year", unique: true
+    t.index ["name"], name: "index_years_on_name", unique: true
   end
 
   add_foreign_key "classrooms", "school_years"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-year = Year.find_or_create_by(year: 2024)
+year = Year.find_or_create_by(name: "2024")
 
 school = School.find_or_create_by(name: "Test School")
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,10 @@
 #   end
 
 year = Year.find_or_create_by(name: "2024")
+(2024...2036).each do |i|
+  year = Year.find_or_create_by(name: "#{i} - #{i + 1}")
+  year.save!
+end
 
 school = School.find_or_create_by(name: "Test School")
 

--- a/test/factories/years.rb
+++ b/test/factories/years.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :year do
-    sequence(:year) { |n| 2000 + n }
+    sequence(:name) { |n| (2000 + n).to_s }
   end
 end

--- a/test/factories/years.rb
+++ b/test/factories/years.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :year do
-    sequence(:name) { |n| (2000 + n).to_s }
+    sequence(:name) { |n| "#{200 + n} - #{2000 + n + 1}" }
   end
 end

--- a/test/models/year_test.rb
+++ b/test/models/year_test.rb
@@ -6,18 +6,18 @@ class YearTest < ActiveSupport::TestCase
   end
 
   test "year presence" do
-    year = build(:year, year: nil)
+    year = build(:year, name: nil)
 
     assert_not year.valid?
-    assert year.errors.added?(:year, :blank)
+    assert year.errors.added?(:name, :blank)
   end
 
   test "year uniqueness" do
-    duplicate_year = 2025
-    create(:year, year: duplicate_year)
-    year = build(:year, year: duplicate_year)
+    duplicate_year = "2025"
+    create(:year, name: duplicate_year)
+    year = build(:year, name: duplicate_year)
 
     assert_not year.valid?
-    assert year.errors.added?(:year, :taken, value: duplicate_year)
+    assert year.errors.added?(:name, :taken, value: duplicate_year)
   end
 end

--- a/test/models/year_test.rb
+++ b/test/models/year_test.rb
@@ -13,7 +13,7 @@ class YearTest < ActiveSupport::TestCase
   end
 
   test "year uniqueness" do
-    duplicate_year = "2025"
+    duplicate_year = "2025 - 2026"
     create(:year, name: duplicate_year)
     year = build(:year, name: duplicate_year)
 


### PR DESCRIPTION
- Replaced the `year` attribute with `name` across the `Year` model.
- Updated validations, migrations, related controllers, views, tests, and seeds to reflect the updated naming and data type.
Fixing #244 