### PR TITLE
Fix #247: Add Teacher, Student, Admin seeds, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,17 @@ It is **strongly** recommend to use Docker. See instructions above.
 
 ## Seed Data
 
-The application includes seed data to create default users for testing. After setting up the database, you can seed it with: `bin/rails db:seed`
+After running `bin/rails db:setup`, the database will automatically be seeded with three default users.
 
-This creates three users:
+| Role    | Username | Email                  | Password |
+|---------|----------|------------------------|----------|
+| Teacher | Teacher  | teacher@example.com    | password |
+| Student | Student  | student@example.com    | password |
+| Admin   | Admin    | admin@example.com      | password |
 
-Teacher: Username: Teacher, Password: password (Email: teacher@example.com)
+Use the **username** and **password** to log in and test the application locally.
 
-Student: Username: Student, Password: password (Email: student@example.com)
-
-Admin: Username: Admin, Password: password (Email: admin@example.com)
-
-Use the username and password to log in and test the application locally or on a deployed environment. 
-
-Note: Do not run db:seed in production unless explicitly required.
+> ⚠️ **Note:** Do not run `db:seed` in production unless explicitly required.
 
 ## URL
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,7 @@ classroom = Classroom.find_or_create_by(name: "Smith's Sixth Grade", school_year
 User.destroy_all
 
 # Create users with usernames and admin flag
-User.create!(
+Teacher.create!(
   username: "Teacher",
   email: "teacher@example.com",
   password: "password",
@@ -33,7 +33,7 @@ User.create!(
   classroom: classroom
 )
 
-User.create!(
+Student.create!(
   username: "Student",
   email: "student@example.com",
   password: "password",


### PR DESCRIPTION
Issue: Resolves #247

Changes:

- Updated db/seeds.rb to create three users (Teacher, Student, Admin) with usernames matching their roles, emails, and password "password". Used admin: true for the Admin user (no role column exists).

- Ensured idempotency in db/seeds.rb by clearing existing users.

- Updated README.md with seed data instructions, specifying username-based login and credentials.


Testing:

- Ran bin/rails db:seed and verified users were created with correct usernames and admin flags.

- Logged in as each user (Teacher, Student, Admin) using username and password.

