### PR TITLE
Reorder FORM_ATTRIBUTES in StudentDashboard

### DIFF
--- a/app/dashboards/student_dashboard.rb
+++ b/app/dashboards/student_dashboard.rb
@@ -44,10 +44,10 @@ class StudentDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
+    username
     classroom
     email
     portfolio
-    username
   ].freeze
 
   # COLLECTION_FILTERS


### PR DESCRIPTION
Fix #259 
- Reordered username form field to the first order of admin student ( /admin/students/new ) page 

![image](https://github.com/user-attachments/assets/03bf93ff-b872-4c26-b706-36a478589e14)
