### PR TITLE
fix: remove schools routes 271

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,12 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
 
-  root "schools#index"
+  root "classrooms#index"
 
   devise_for :users
 
   namespace :admin do
-    root to: "classrooms#index"
-
+    root "classrooms#index"
     resources :classrooms
     resources :portfolio_transactions, except: [:index]
     resources :school_years, except: %i[new edit]
@@ -25,6 +24,5 @@ Rails.application.routes.draw do
   resources :orders
   resources :portfolios, only: :show
   resources :stocks, only: %i[show index]
-  resources :schools
   resources :students, only: :show
 end

--- a/test/controllers/admin/schools_controller_test.rb
+++ b/test/controllers/admin/schools_controller_test.rb
@@ -5,7 +5,7 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     admin = create(:admin)
     sign_in admin
 
-    get schools_url
+    get admin_schools_url
 
     assert_response :success
   end
@@ -14,7 +14,7 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     admin = create(:admin)
     sign_in admin
 
-    get new_school_url
+    get new_admin_school_url
 
     assert_response :success
   end
@@ -25,10 +25,10 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     sign_in admin
 
     assert_difference("School.count") do
-      post(schools_url, params:)
+      post(admin_schools_url, params:)
     end
 
-    assert_redirected_to school_url(School.last)
+    assert_redirected_to admin_school_url(School.last)
   end
 
   test "show" do
@@ -36,7 +36,7 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     admin = create(:admin)
     sign_in admin
 
-    get school_url(school)
+    get admin_school_url(school)
 
     assert_response :success
   end
@@ -46,7 +46,7 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     admin = create(:admin)
     sign_in admin
 
-    get edit_school_url(school)
+    get edit_admin_school_url(school)
 
     assert_response :success
   end
@@ -58,10 +58,10 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     sign_in admin
 
     assert_changes "school.reload.updated_at" do
-      patch school_url(school), params:
+      patch admin_school_url(school), params:
     end
 
-    assert_redirected_to school_url(school)
+    assert_redirected_to admin_school_url(school)
   end
 
   test "destroy" do
@@ -70,9 +70,9 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     sign_in admin
 
     assert_difference("School.count", -1) do
-      delete school_url(school)
+      delete admin_school_url(school)
     end
 
-    assert_redirected_to schools_url
+    assert_redirected_to admin_schools_url
   end
 end


### PR DESCRIPTION
This PR should close out the issue [Remove schools routes](https://github.com/rubyforgood/stocks-in-the-future/issues/271)

by:
- setting the root route to always be the index classrooms page
- removing the generic schools routes, but leaving them in for the admin namespace
- moving the school tests over to the admin folder, and updating them to use the admin_school urls

Test manually by running locally, logging in as `Teacher` / `password` and making sure the root route is Classrooms, and the user has no way of accessing the schools routes. 

<img width="1215" alt="Screenshot 2025-06-08 at 2 24 28 PM" src="https://github.com/user-attachments/assets/cb65cf34-36de-4c4a-a8dc-3c737cac4dfc" />
<img width="1217" alt="Screenshot 2025-06-08 at 2 24 42 PM" src="https://github.com/user-attachments/assets/3f78789c-53ec-4fe6-a1b7-e9ffec991077" />


Then log in as `Admin` / `password` and make sure you can still CRUD the schools via the admin dashboard.

<img width="1217" alt="Screenshot 2025-06-08 at 2 25 01 PM" src="https://github.com/user-attachments/assets/620fe53e-6cc9-48a8-9f22-b00bea213c6f" />
<img width="1218" alt="Screenshot 2025-06-08 at 2 25 14 PM" src="https://github.com/user-attachments/assets/426be6d3-342b-46de-95e2-4ae857fcdc14" />
