### PR TITLE
Added role column to user index page

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -11,7 +11,8 @@ class UserDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    classroom_id: Field::Number,
+    classroom: Field::BelongsTo,
+    type: Field::String,
     email: Field::String,
     portfolio: Field::HasOne,
     username: Field::String,
@@ -26,7 +27,8 @@ class UserDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
-    classroom_id
+    classroom
+    type
     email
   ].freeze
 
@@ -34,7 +36,8 @@ class UserDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    classroom_id
+    classroom
+    type
     email
     portfolio
     username
@@ -46,7 +49,8 @@ class UserDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    classroom_id
+    classroom
+    type
     email
     portfolio
     username

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,7 @@ en:
       notice: Classroom was successfully destroyed.
     update:
       notice: Classroom was successfully updated.
+  activerecord:
+    attributes:
+      user:
+        type: "Role"


### PR DESCRIPTION
[Issue #286](https://github.com/rubyforgood/stocks-in-the-future/issues/286)

### Description
Add a column for "Role" to the Admin Users table and update the classroom column to show the name of the classroom instead of the ID.

### Demo

**BEFORE**
![Screenshot 2025-07-01 at 10 00 22 AM](https://github.com/user-attachments/assets/3f774d1c-3f86-4bc0-aa01-738053867b34)

**AFTER**
<img width="1258" alt="Screenshot 2025-07-01 at 9 55 32 AM" src="https://github.com/user-attachments/assets/3d15a109-99b5-4571-9b9d-5adc607fc54b" />
