### PR TITLE
issue-332 add standard button styling

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,4 +1,8 @@
 @import 'shadcn.css';
+
+/* SIF custom CSS */
+@import 'custom/buttons.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -56,4 +60,3 @@
     @apply relative rounded-full bg-white p-1 text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none;
   }
 }
-

--- a/app/assets/stylesheets/custom/buttons.css
+++ b/app/assets/stylesheets/custom/buttons.css
@@ -1,0 +1,7 @@
+.tw-btn-primary {
+  @apply rounded-md bg-[#00698c] px-4 py-2 text-sm font-semibold text-white hover:bg-[#004f6b] focus-visible:outline-2 focus-visible:outline-offset-2;
+}
+
+.tw-btn-secondary {
+  @apply rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50
+}

--- a/app/views/stocks/_stocks_table.html.erb
+++ b/app/views/stocks/_stocks_table.html.erb
@@ -22,12 +22,12 @@
       </td>
       <% if current_user.student? %>
         <td class="px-4 py-2">
-          <button type="button" class="rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50">
+          <button type="button" class="tw-btn-secondary">
             Buy
           </button>
         </td>
         <td class="py-2">
-          <button type="button" class="rounded-md bg-[#00698c] px-4 py-2 text-sm font-semibold text-white shadow-xs hover:bg-[#004f6b] focus-visible:outline-2 focus-visible:outline-offset-2">
+          <button type="button" class="tw-btn-primary">
             Sell
           </button>
         </td>


### PR DESCRIPTION
We want a solution that everyone knows. [ViewComponent](https://github.com/ViewComponent/view_component) seems like overkill.

Just some light css. organized under the `/custom` subdir. Not sure about how we want to name classes.

Pull the branch, rebuild and log in as a student. Go to their trading floor and the "buy" "sell" buttons should look exactly the same.

This is just laying a seam. I expect follow up `*.css` files for `inputs` or `forms`, etc.

## Consideration
- for some reason, `shadow-xs` doesnt play nice. so i removed it. its a tw standard, but why? ill need to dig
