### PR TITLE
[Issue-332] more consolidation of buttons styles; also forms.css for input element styles

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,7 @@
 
 /* SIF custom CSS */
 @import 'custom/buttons.css';
+@import 'custom/forms.css';
 
 @tailwind base;
 @tailwind components;

--- a/app/assets/stylesheets/custom/buttons.css
+++ b/app/assets/stylesheets/custom/buttons.css
@@ -1,14 +1,23 @@
 .tw-btn-sell {
   @apply rounded-md bg-[#00698c] px-4 py-2 text-sm font-semibold text-white hover:bg-[#004f6b] focus-visible:outline-2 focus-visible:outline-offset-2;
 }
+
 .tw-btn-buy {
   @apply rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50
 }
 
 .tw-btn-primary {
-  @apply rounded-md bg-[#00698c] px-4 py-2 text-sm font-semibold text-white hover:bg-[#004f6b] focus-visible:outline-2 focus-visible:outline-offset-2;
+  @apply rounded-lg py-3 px-5 bg-indigo-600 text-white block font-medium
 }
 
 .tw-btn-secondary {
   @apply rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50
+}
+
+.tw-btn-tertiary {
+  @apply ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium
+}
+
+.tw-btn-danger {
+  @apply rounded-lg py-3 ml-2 px-5 bg-red-100 text-red-500 inline-block font-medium hover:text-red-900
 }

--- a/app/assets/stylesheets/custom/buttons.css
+++ b/app/assets/stylesheets/custom/buttons.css
@@ -1,3 +1,10 @@
+.tw-btn-sell {
+  @apply rounded-md bg-[#00698c] px-4 py-2 text-sm font-semibold text-white hover:bg-[#004f6b] focus-visible:outline-2 focus-visible:outline-offset-2;
+}
+.tw-btn-buy {
+  @apply rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50
+}
+
 .tw-btn-primary {
   @apply rounded-md bg-[#00698c] px-4 py-2 text-sm font-semibold text-white hover:bg-[#004f6b] focus-visible:outline-2 focus-visible:outline-offset-2;
 }

--- a/app/assets/stylesheets/custom/forms.css
+++ b/app/assets/stylesheets/custom/forms.css
@@ -1,0 +1,7 @@
+.tw-label-primary {
+  @apply block text-sm/6 font-medium text-gray-900
+}
+
+.tw-input-primary {
+  @apply block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6
+}

--- a/app/views/classrooms/_classroom.html.erb
+++ b/app/views/classrooms/_classroom.html.erb
@@ -20,10 +20,10 @@
   </p>
 
   <% if action_name != "show" %>
-    <%= link_to "Show this classroom", classroom, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <%= link_to "Edit this classroom", edit_classroom_path(classroom), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Show this classroom", classroom, class: "tw-btn-tertiary" %>
+    <%= link_to "Edit this classroom", edit_classroom_path(classroom), class: "tw-btn-tertiary" %>
     <%= link_to "Delete this classroom", classroom_path(classroom),
-                class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium",
+                class: "tw-btn-danger",
                 data: {
                   turbo_method: :delete,
                 } %>

--- a/app/views/classrooms/_classroom_students_table.html.erb
+++ b/app/views/classrooms/_classroom_students_table.html.erb
@@ -4,7 +4,7 @@
     <% if @can_manage_students %>
       <div class="flex gap-2">
         <%= link_to "Add Student", new_classroom_student_path(@classroom),
-            class: "inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700" %>
+            class: "tw-btn-primary" %>
         <!-- TODO: Add bulk functionality in future PR -->
       </div>
     <% end %>
@@ -35,7 +35,7 @@
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
               <% if student.portfolio %>
-                <%= link_to "View Portfolio", user_portfolio_path(student, student.portfolio), class: "text-blue-600 hover:text-blue-900" %>
+                <%= link_to "View Portfolio", user_portfolio_path(student, student.portfolio), class: "tw-btn-secondary" %>
               <% else %>
                 <span class="text-gray-400">No portfolio</span>
               <% end %>
@@ -63,7 +63,7 @@
                         turbo_method: :delete,
                         turbo_confirm: "Are you sure you want to delete #{student.username}?"
                       },
-                      class: "text-red-600 hover:text-red-900" %>
+                      class: "tw-btn-danger" %>
                 </div>
               </td>
             <% end %>

--- a/app/views/classrooms/_form.html.erb
+++ b/app/views/classrooms/_form.html.erb
@@ -12,23 +12,31 @@
   <% end %>
 
   <div class="my-5">
-    <%= form.label :name %>
-    <%= form.text_field :name, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :name, class: 'tw-label-primary' %>
+    <div class="mt-2">
+      <%= form.text_field :name, class: "tw-input-primary" %>
+    </div>
   </div>
 
   <div class="my-5">
-    <%= form.label :school_name, "School Name" %>
-    <%= form.text_field :school_name, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :school_name, "School Name", class: 'tw-label-primary' %>
+    <div class="mt-2">
+      <%= form.text_field :school_name, class: "tw-input-primary" %>
+    </div>
   </div>
 
   <div class="my-5">
-    <%= form.label :year_value, "Year" %>
-    <%= form.text_field :year_value, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :year_value, "Year", class: 'tw-label-primary' %>
+    <div class="mt-2">
+      <%= form.text_field :year_value, class: "tw-input-primary" %>
+    </div>
   </div>
 
   <div class="my-5">
-    <%= form.label :grade %>
-    <%= form.text_field :grade, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :grade, class: 'tw-label-primary' %>
+    <div class="mt-2">
+      <%= form.text_field :grade, class: "tw-input-primary" %>
+    </div>
   </div>
 
   <div class="inline">

--- a/app/views/classrooms/_form.html.erb
+++ b/app/views/classrooms/_form.html.erb
@@ -32,6 +32,6 @@
   </div>
 
   <div class="inline">
-    <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+    <%= form.submit class: "tw-btn-primary" %>
   </div>
 <% end %>

--- a/app/views/classrooms/edit.html.erb
+++ b/app/views/classrooms/edit.html.erb
@@ -3,6 +3,6 @@
 
   <%= render "form", classroom: @classroom %>
 
-  <%= link_to "Show this classroom", @classroom, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-  <%= link_to "Back to classrooms", classrooms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Show this classroom", @classroom, class: "tw-btn-tertiary" %>
+  <%= link_to "Back to classrooms", classrooms_path, class: "tw-btn-tertiary" %>
 </div>

--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -5,7 +5,7 @@
 
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Classrooms</h1>
-    <%= link_to "New classroom", new_classroom_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+    <%= link_to "New classroom", new_classroom_path, class: "tw-btn-primary" %>
   </div>
 
   <div id="classrooms" class="min-w-full">

--- a/app/views/classrooms/new.html.erb
+++ b/app/views/classrooms/new.html.erb
@@ -3,5 +3,5 @@
 
   <%= render "form", classroom: @classroom %>
 
-  <%= link_to "Back to classrooms", classrooms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to classrooms", classrooms_path, class: "tw-btn-tertiary" %>
 </div>

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -7,10 +7,10 @@
     <%= render @classroom %>
     <%= render 'classroom_students_table', students: @classroom.users %>
 
-    <%= link_to "Edit this classroom", edit_classroom_path(@classroom), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Edit this classroom", edit_classroom_path(@classroom), class: "tw-btn-tertiary" %>
     <div class="inline-block ml-2">
-      <%= button_to "Destroy this classroom", classroom_path(@classroom), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      <%= button_to "Destroy this classroom", classroom_path(@classroom), method: :delete, class: "tw-btn-danger" %>
     </div>
-    <%= link_to "Back to classrooms", classrooms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Back to classrooms", classrooms_path, class: "tw-btn-tertiary" %>
   </div>
 </div>

--- a/app/views/schools/_school.html.erb
+++ b/app/views/schools/_school.html.erb
@@ -5,8 +5,8 @@
   </p>
 
   <% if action_name != "show" %>
-    <%= link_to "Show this school", school, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <%= link_to "Edit this school", edit_school_path(school), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Show this school", school, class: "tw-btn-secondary" %>
+    <%= link_to "Edit this school", edit_school_path(school), class: "tw-btn-secondary" %>
     <hr class="mt-6">
   <% end %>
 </div>

--- a/app/views/schools/edit.html.erb
+++ b/app/views/schools/edit.html.erb
@@ -3,6 +3,6 @@
 
   <%= render "form", school: @school %>
 
-  <%= link_to "Show this school", @school, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-  <%= link_to "Back to schools", schools_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Show this school", @school, class: "tw-btn-secondary" %>
+  <%= link_to "Back to schools", schools_path, class: "tw-btn-secondary" %>
 </div>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -6,7 +6,7 @@
     <%= render @school %>
     <%= link_to "Edit this school", edit_school_path(@school), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
-      <%= button_to "Destroy this school", school_path(@school), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      <%= button_to "Destroy this school", school_path(@school), method: :delete, class: "tw-btn-danger" %>
     </div>
     <%= link_to "Back to schools", schools_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
   </div>

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -96,7 +96,7 @@
   </p>
 
   <% if action_name != "show" %>
-    <%= link_to "Show this stock", stock, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Show this stock", stock, class: "tw-btn-secondary" %>
     <hr class="mt-6">
   <% end %>
 </div>

--- a/app/views/stocks/_stocks_table.html.erb
+++ b/app/views/stocks/_stocks_table.html.erb
@@ -22,12 +22,12 @@
       </td>
       <% if current_user.student? %>
         <td class="px-4 py-2">
-          <button type="button" class="tw-btn-secondary">
+          <button type="button" class="tw-btn-buy">
             Buy
           </button>
         </td>
         <td class="py-2">
-          <button type="button" class="tw-btn-primary">
+          <button type="button" class="tw-btn-sell">
             Sell
           </button>
         </td>

--- a/app/views/stocks/show.html.erb
+++ b/app/views/stocks/show.html.erb
@@ -6,6 +6,6 @@
 
     <%= render @stock %>
 
-    <%= link_to "Back to stocks", stocks_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to "Back to stocks", stocks_path, class: "tw-btn-tertiary" %>
   </div>
 </div>


### PR DESCRIPTION
We want to encourage tailwind utility class changes to be streamlined -- in one place. That way, it just cascades to all the view elements automatically.
- More button work
- Css file to consolidate form element style classes

## Buttons
We do that here for buttons -- they are centralized as css classes in `app/assets/stylesheets/custom/buttons.css`. I did not swap out all partials with direct tw utility class markups. That will come later, when those flows are worked on.

The focus here is consolidation. We expect change, eg `tw-btn-buy` and `tw-btn-sell` were simply created to accommodate the likelihood that they are different from the rest.

## Forms
Same idea with form elements.

<img width="1229" alt="Screenshot 2025-07-03 at 2 17 27 PM" src="https://github.com/user-attachments/assets/fd7507ae-8138-4ac8-8611-680f4a0bf038" />

<img width="915" alt="Screenshot 2025-07-03 at 4 01 15 PM" src="https://github.com/user-attachments/assets/addfbbed-5b68-47cf-abd5-ca80182fc46c" />

