### PR TITLE
Fix year select in school edit 288

### DIFF
--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -46,7 +46,6 @@ class SchoolDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     name
-    school_years
     years
   ].freeze
 

--- a/app/dashboards/year_dashboard.rb
+++ b/app/dashboards/year_dashboard.rb
@@ -64,8 +64,7 @@ class YearDashboard < Administrate::BaseDashboard
 
   # Overwrite this method to customize how years are displayed
   # across all pages of the admin dashboard.
-  #
-  # def display_resource(year)
-  #   "Year ##{year.id}"
-  # end
+  def display_resource(year)
+    year.name
+  end
 end


### PR DESCRIPTION
Fixes #288
- Removed the school_year select field from the new and edit forms in the School dashboard.
- Updated the admin interface to display the year name instead of the default '`Year #1`' format for Year records.