### PR TITLE
feat(orders): display earnings for sell orders

### DIFF
--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -38,8 +38,7 @@
 
 
     <div class="pb-3">
-      <p class="text-sm font-semibold text-gray-700">
-        Total Cost: <span data-order-form-target="totalCost">$0.00</span>
+      <p class="text-sm font-semibold text-gray-700">Total <%= order.transaction_type == 'buy' ? 'Cost' : 'Earnings' %> : <span data-order-form-target="totalCost">$0.00</span>
       </p>
     </div>
 


### PR DESCRIPTION
I have updated the "Total Earnings" text when selling the stock. Made sure to show "Total Costs" when buying stocks aswell.

Selling Stock:
<img width="1204" height="736" alt="image" src="https://github.com/user-attachments/assets/b99e6a4c-5f18-4e10-9925-b5d3ce428998" />

Buying Stock:
<img width="707" height="513" alt="image" src="https://github.com/user-attachments/assets/a0e13b43-0d73-4472-8232-2f3ec7e6c583" />

close #402 