### PR TITLE
Remove "Back to classrooms" link from classroom show view

### DIFF
--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -17,6 +17,5 @@
           class: "tw-btn-danger" %>
       </div>
     <% end %>
-    <%= link_to "Back to classrooms", classrooms_path, class: "tw-btn-tertiary" %>
   </div>
 </div>


### PR DESCRIPTION
Fixes #399 