### PR TITLE
Add stock attributes update job and service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,10 @@
 #ignore kilocodemodes config files
 .kilocodemodes
 
+# Ignore AI assistant configuration files
+.claude/
+
+# Ignore VSCode global storage (contains extension settings)
+Library/
+
 .idea

--- a/app/jobs/stock_attribute_update_job.rb
+++ b/app/jobs/stock_attribute_update_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class StockAttributeUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Stock.find_each do |stock|
+      Rails.logger.info "Processing stock attribute update for #{stock.ticker}"
+
+      StockAttributeUpdate.execute(stock)
+    end
+  end
+end

--- a/app/services/stock_attribute_update.rb
+++ b/app/services/stock_attribute_update.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+class StockAttributeUpdate
+  def initialize(stock)
+    @stock = stock
+  end
+
+  def self.execute(stock)
+    new(stock).execute
+  end
+
+  def execute
+    return if stock.ticker.blank?
+
+    log_start_update
+    data = fetch_api_data
+
+    return unless valid_api_response?(data)
+
+    update_stock_attributes(data)
+    save_stock
+  end
+
+  private
+
+  attr_reader :stock
+
+  def log_start_update
+    Rails.logger.info "Updating attributes for stock #{stock.ticker}"
+  end
+
+  def fetch_api_data
+    api_request(stock.ticker)
+  end
+
+  def valid_api_response?(data)
+    if data && data["Symbol"]
+      Rails.logger.info "API returned data for #{stock.ticker}"
+      true
+    else
+      Rails.logger.error "Invalid API response for #{stock.ticker}: #{data}"
+      false
+    end
+  end
+
+  def save_stock
+    if stock.save
+      Rails.logger.info "Successfully updated attributes for #{stock.ticker}"
+    else
+      Rails.logger.error "Failed to save #{stock.ticker}: #{stock.errors.full_messages}"
+    end
+  end
+
+  def update_stock_attributes(data)
+    update_basic_info(data)
+    update_financial_info(data)
+  end
+
+  def update_basic_info(data)
+    stock.company_name = data["Name"] if data["Name"]
+    stock.description = data["Description"] if data["Description"]
+    stock.stock_exchange = data["Exchange"] if data["Exchange"]
+    stock.industry = data["Industry"] if data["Industry"]
+  end
+
+  def update_financial_info(data)
+    stock.company_website = data["OfficialSite"] if data["OfficialSite"]
+    stock.profit_margin = data["ProfitMargin"].to_f if data["ProfitMargin"]
+  end
+
+  def api_request(symbol)
+    url = "https://www.alphavantage.co/query?function=OVERVIEW&symbol=#{symbol}&apikey=#{API_KEY}"
+    uri = URI.parse(url)
+    JSON.parse Net::HTTP.get(uri)
+  rescue JSON::ParserError, Net::HTTPError => e
+    Rails.logger.error "API request failed for #{symbol}: #{e.message}"
+    nil
+  end
+end

--- a/test/jobs/stock_attribute_update_job_test.rb
+++ b/test/jobs/stock_attribute_update_job_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StockAttributeUpdateJobTest < ActiveJob::TestCase
+  test "processes all stocks in the database" do
+    stock1 = create(:stock, ticker: "STOCK1")
+    stock2 = create(:stock, ticker: "STOCK2")
+    stock3 = create(:stock, ticker: "STOCK3")
+
+    Net::HTTP.expects(:get).times(3).returns(
+      { "Symbol" => "STOCK1", "Name" => "Company 1" }.to_json,
+      { "Symbol" => "STOCK2", "Name" => "Company 2" }.to_json,
+      { "Symbol" => "STOCK3", "Name" => "Company 3" }.to_json
+    )
+
+    StockAttributeUpdateJob.perform_now
+
+    stock1.reload
+    stock2.reload
+    stock3.reload
+
+    assert_equal "Company 1", stock1.company_name
+    assert_equal "Company 2", stock2.company_name
+    assert_equal "Company 3", stock3.company_name
+  end
+
+  test "handles stocks with invalid API responses" do
+    stock1 = create(:stock, ticker: "VALID")
+    stock2 = create(:stock, ticker: "INVALID")
+
+    original_name = stock2.company_name
+
+    Net::HTTP.expects(:get).times(2).returns(
+      { "Symbol" => "VALID", "Name" => "Valid Company" }.to_json,
+      "{}"
+    )
+
+    StockAttributeUpdateJob.perform_now
+
+    stock1.reload
+    stock2.reload
+
+    assert_equal "Valid Company", stock1.company_name
+    assert_equal original_name, stock2.company_name
+  end
+
+  test "skips stocks without ticker" do
+    stock_with_ticker = create(:stock, ticker: "HAS_TICKER")
+    stock_without_ticker = Stock.new(description: "Test stock")
+    stock_without_ticker.save(validate: false)
+
+    Net::HTTP.expects(:get).once.returns(
+      { "Symbol" => "HAS_TICKER", "Name" => "Has Ticker Company" }.to_json
+    )
+
+    StockAttributeUpdateJob.perform_now
+
+    stock_with_ticker.reload
+    stock_without_ticker.reload
+
+    assert_equal "Has Ticker Company", stock_with_ticker.company_name
+    assert_nil stock_without_ticker.company_name
+  end
+
+  test "handles empty stock table" do
+    Stock.delete_all
+    Net::HTTP.expects(:get).never
+
+    assert_nothing_raised do
+      StockAttributeUpdateJob.perform_now
+    end
+  end
+end

--- a/test/services/stock_attribute_update_test.rb
+++ b/test/services/stock_attribute_update_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StockAttributeUpdateTest < ActiveSupport::TestCase
+  test "updates stock attributes from valid API response" do
+    stock = create(:stock, ticker: "TEST")
+
+    mock_response = {
+      "Symbol" => "TEST",
+      "Name" => "Test Company",
+      "Description" => "A test company description",
+      "Exchange" => "NYSE",
+      "Industry" => "TECHNOLOGY",
+      "OfficialSite" => "https://test.com",
+      "ProfitMargin" => "0.15"
+    }
+
+    Net::HTTP.expects(:get).returns(mock_response.to_json)
+
+    StockAttributeUpdate.execute(stock)
+    stock.reload
+
+    assert_equal "Test Company", stock.company_name
+    assert_equal "A test company description", stock.description
+    assert_equal "NYSE", stock.stock_exchange
+    assert_equal "TECHNOLOGY", stock.industry
+    assert_equal "https://test.com", stock.company_website
+    assert_equal 0.15, stock.profit_margin
+  end
+
+  test "handles invalid API response gracefully" do
+    stock = create(:stock, ticker: "INVALID")
+
+    Net::HTTP.expects(:get).returns("{}")
+
+    original_updated_at = stock.updated_at
+
+    StockAttributeUpdate.execute(stock)
+    stock.reload
+
+    assert_equal original_updated_at, stock.updated_at
+  end
+
+  test "handles API error gracefully" do
+    stock = create(:stock, ticker: "ERROR")
+
+    Net::HTTP.expects(:get).raises(JSON::ParserError.new("Invalid JSON"))
+
+    original_updated_at = stock.updated_at
+
+    StockAttributeUpdate.execute(stock)
+    stock.reload
+
+    assert_equal original_updated_at, stock.updated_at
+  end
+
+  test "skips stock without ticker" do
+    stock = Stock.new(description: "Test stock")
+    stock.save(validate: false)
+
+    Net::HTTP.expects(:get).never
+
+    StockAttributeUpdate.execute(stock)
+    stock.reload
+
+    assert_nil stock.company_name
+  end
+
+  test "handles API response with missing fields" do
+    stock = create(:stock, ticker: "PARTIAL")
+
+    mock_response = {
+      "Symbol" => "PARTIAL",
+      "Name" => "Partial Company"
+    }
+
+    Net::HTTP.expects(:get).returns(mock_response.to_json)
+
+    StockAttributeUpdate.execute(stock)
+    stock.reload
+
+    assert_equal "Partial Company", stock.company_name
+    assert_equal "A sample stock for testing", stock.description
+    assert_equal "NYSE", stock.stock_exchange
+  end
+end


### PR DESCRIPTION
Resolves #280 

This introduces a new  service and background job to automatically update stock company information. The feature fetches comprehensive company data (name, description, industry, exchange, website, profit margin) and updates existing stock records in the database.

