### PR TITLE
adding current price and ticker to the admin stock

### DIFF
--- a/app/dashboards/stock_dashboard.rb
+++ b/app/dashboards/stock_dashboard.rb
@@ -26,6 +26,7 @@ class StockDashboard < Administrate::BaseDashboard
     management: Field::Text,
     portfolio_stocks: Field::HasMany,
     price_cents: Field::String.with_options(searchable: false),
+    current_price: Field::Number.with_options(searchable: false, format: { formatter: :number_to_currency }),
     profit_margin: Field::String.with_options(searchable: false),
     sales_growth: Field::String.with_options(searchable: false),
     stock_exchange: Field::String,
@@ -41,9 +42,11 @@ class StockDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
-    cash_flow
+    ticker
     company_name
     company_website
+    cash_flow
+    current_price
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -64,7 +67,7 @@ class StockDashboard < Administrate::BaseDashboard
     industry_avg_sales_growth
     management
     portfolio_stocks
-    price_cents
+    current_price
     profit_margin
     sales_growth
     stock_exchange
@@ -116,4 +119,8 @@ class StockDashboard < Administrate::BaseDashboard
   # def display_resource(stock)
   #   "Stock ##{stock.id}"
   # end
+
+  def display_resource(stock)
+    "#{stock.ticker} - #{stock.company_name}"
+  end
 end

--- a/test/controllers/admin/stocks_controller_test.rb
+++ b/test/controllers/admin/stocks_controller_test.rb
@@ -25,5 +25,14 @@ module Admin
       assert_redirected_to admin_stock_path(Stock.last)
       assert_equal "Stock was successfully created.", flash[:notice]
     end
+
+    test "index" do
+      admin = create(:admin)
+      sign_in(admin)
+
+      get admin_stocks_path
+
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
https://github.com/rubyforgood/stocks-in-the-future/issues/436

- use current_price with currency formatter
- adding smoke test for the index
- update resource display with ticker + name

## current price + ticker
<img width="800" height="381" alt="Screenshot 2025-08-31 at 17 32 33" src="https://github.com/user-attachments/assets/ebd38fe9-b476-4712-87a4-51ed9694c38d" />

## display resource

<img width="800" height="388" alt="Screenshot 2025-08-31 at 17 33 49" src="https://github.com/user-attachments/assets/c0aa19bc-204e-43e7-a5be-b338590341cc" />

## still update price cents

<img width="575" height="381" alt="image" src="https://github.com/user-attachments/assets/4587440c-094d-4f27-af29-f639015872ef" />
