### PR TITLE
#430 stock can be archived

### DIFF
--- a/app/dashboards/stock_dashboard.rb
+++ b/app/dashboards/stock_dashboard.rb
@@ -11,6 +11,7 @@ class StockDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
+    archived: Field::Boolean,
     cash_flow: Field::String.with_options(searchable: false),
     company_name: Field::String,
     company_website: Field::String,
@@ -45,14 +46,15 @@ class StockDashboard < Administrate::BaseDashboard
     ticker
     company_name
     company_website
-    cash_flow
     current_price
+    archived
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
+    archived
     cash_flow
     company_name
     company_website
@@ -80,6 +82,7 @@ class StockDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
+    archived
     cash_flow
     company_name
     company_website

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -6,6 +6,9 @@ class Stock < ApplicationRecord
 
   validates :ticker, presence: true
 
+  scope :active, -> { where(archived: false) }
+  scope :archived, -> { where(archived: true) }
+
   def current_price
     price_cents / 100.0
   end

--- a/db/migrate/20250903103019_add_archived_to_stocks.rb
+++ b/db/migrate/20250903103019_add_archived_to_stocks.rb
@@ -1,0 +1,5 @@
+class AddArchivedToStocks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stocks, :archived, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_29_013912) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_03_103019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -154,6 +154,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_29_013912) do
     t.decimal "cash_flow", precision: 15, scale: 2
     t.decimal "debt", precision: 15, scale: 2
     t.integer "price_cents"
+    t.boolean "archived", default: false, null: false
     t.index ["ticker"], name: "index_stocks_on_ticker", unique: true
   end
 

--- a/test/models/stock_test.rb
+++ b/test/models/stock_test.rb
@@ -14,4 +14,23 @@ class StockTest < ActiveSupport::TestCase
 
     assert_equal 10.0, result
   end
+
+  test "archived defaults to false" do
+    stock = create(:stock)
+
+    assert_equal false, stock.archived
+  end
+
+  test "active and archived scopes filter correctly" do
+    active_stock = create(:stock, archived: false)
+    archived_stock = create(:stock, archived: true)
+
+    active_stocks = Stock.active
+    archived_stocks = Stock.archived
+
+    assert_includes active_stocks, active_stock
+    assert_not_includes active_stocks, archived_stock
+    assert_includes archived_stocks, archived_stock
+    assert_not_includes archived_stocks, active_stock
+  end
 end


### PR DESCRIPTION
It resolves https://github.com/rubyforgood/stocks-in-the-future/issues/430

- Adding archived attribute 
- Show the new attributes on the admin page
- Admin can see and edit the new attribute
- Active and archived scopes

## admin stock index

I added the attribute and remove the `cash_flow` to keep information minimal and useful 

<img width="800" height="338" alt="Screenshot 2025-09-03 at 12 50 08" src="https://github.com/user-attachments/assets/48e00358-12c0-4314-b3fd-7953a10b5edc" />

## admin stock edit form

<img width="800" height="212" alt="Screenshot 2025-09-03 at 12 51 34" src="https://github.com/user-attachments/assets/24b00ec0-71aa-4613-9fbd-cd2c332dd46c" />

