### PR TITLE
Buy or sell order safe for invalid number or shares

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -42,7 +42,13 @@ class Order < ApplicationRecord
 
   private
 
+  def number_of_shares_valid_for_calculations?
+    shares.is_a?(Numeric) && shares > 0
+  end
+
   def sufficient_shares_for_sell
+    return unless number_of_shares_valid_for_calculations?
+    
     current_shares = user.portfolio&.shares_owned(stock_id) || 0
     return unless shares > current_shares
 
@@ -51,6 +57,8 @@ class Order < ApplicationRecord
   end
 
   def sufficient_funds_for_buy
+    return unless number_of_shares_valid_for_calculations?
+    
     current_balance_cents = (user.portfolio&.cash_balance || 0) * 100
     return unless purchase_cost > current_balance_cents
 
@@ -60,6 +68,8 @@ class Order < ApplicationRecord
   end
 
   def sufficient_funds_for_buy_when_update
+    return unless number_of_shares_valid_for_calculations?
+    
     current_balance_cents = (user.portfolio&.cash_balance || 0) * 100
 
     balance_before_transaction = if portfolio_transaction.present?

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -32,7 +32,7 @@
 
     <div class="pb-3">
       <%= form.label "# of shares #{order.action == 'buy' ? 'buying' : 'selling'}" %>
-      <%= form.number_field :shares, min: 1, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", data: { order_form_target: "shares", action: "input->order-form#calculateTotal" } %>
+      <%= form.number_field :shares, min: 1, required: true, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", data: { order_form_target: "shares", action: "input->order-form#calculateTotal" } %>
     </div>
     <hr class="py-3"></hr>
 


### PR DESCRIPTION
- Fixed `nil can't be coerced into Integer` exceptions when submitting orders without shares
- Fixed `undefined method '>' for nil` exceptions on sell orders with nil shares
- Handle validation + HTML5 validation too

## Buy order without valid shares

From:

<img width="400" height="374" alt="image" src="https://github.com/user-attachments/assets/b2662b87-5e55-4f9c-8214-af64414e6f5f" />

To:

<img width="400" height="401" alt="image" src="https://github.com/user-attachments/assets/d2da5b6f-f21f-41b0-86d7-946915416036" />

## Sell order without valid shares

From:
<img width="400" height="246" alt="image" src="https://github.com/user-attachments/assets/cd7b6ef4-0863-4930-89fd-c4817906ca26" />

To:
<img width="400" height="389" alt="image" src="https://github.com/user-attachments/assets/37383c25-2ad9-45b5-9452-1eb01995f9be" />

