### PR TITLE
Fix classroom show page: replace text links with FA icons

### DIFF
--- a/app/views/classrooms/_classroom_students_table.html.erb
+++ b/app/views/classrooms/_classroom_students_table.html.erb
@@ -12,7 +12,6 @@
     <% end %>
   </div>
 
-
   <div class="overflow-x-auto">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
@@ -27,10 +26,10 @@
       </thead>
       <tbody class="bg-white divide-y divide-gray-200">
         <% @students.each do |student| %>
-          <tr>
+          <tr class="hover:bg-gray-50 transition-colors duration-150">
             <td class="px-6 py-4 whitespace-nowrap">
               <% if student.username.present? %>
-                <%= link_to student.username, classroom_student_path(@classroom, student), class: "text-blue-600 hover:text-blue-900" %>
+                <%= link_to student.username, classroom_student_path(@classroom, student), class: "text-blue-600 hover:text-blue-900 font-medium" %>
               <% else %>
                 <span class="text-gray-400 italic">No username set</span>
               <% end %>
@@ -42,7 +41,7 @@
                 <span class="text-gray-400">No portfolio</span>
               <% end %>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-medium">
               <% if student.portfolio %>
                 $<%= number_with_precision(student.portfolio.current_position, precision: 2) %>
               <% else %>
@@ -51,21 +50,35 @@
             </td>
             <% if @can_manage_students %>
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                <div class="flex space-x-2">
-                  <%= link_to "Edit", edit_classroom_student_path(@classroom, student),
-                      class: "text-indigo-600 hover:text-indigo-900" %>
-                  <%= link_to "Reset Password", reset_password_classroom_student_path(@classroom, student),
+                <div class="flex items-center gap-2">
+                  <!-- Edit Button -->
+                  <%= link_to edit_classroom_student_path(@classroom, student),
+                      class: "inline-flex items-center justify-center w-8 h-8 text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded-lg transition-all duration-150 group",
+                      title: "Edit student" do %>
+                    <i class="fa fa-pencil fa-lg group-hover:scale-110 transition-transform duration-150"></i>
+                  <% end %>
+
+                  <!-- Reset Password Button -->
+                  <%= link_to reset_password_classroom_student_path(@classroom, student),
                       data: {
                         turbo_method: :patch,
                         turbo_confirm: "Are you sure you want to reset #{student.username}'s password?"
                       },
-                      class: "text-yellow-600 hover:text-yellow-900" %>
-                  <%= link_to "Delete", classroom_student_path(@classroom, student),
+                      class: "inline-flex items-center justify-center w-8 h-8 text-amber-600 hover:text-amber-800 hover:bg-amber-50 rounded-lg transition-all duration-150 group",
+                      title: "Reset password" do %>
+                    <i class="fa fa-key fa-lg group-hover:scale-110 transition-transform duration-150"></i>
+                  <% end %>
+
+                  <!-- Delete Button -->
+                  <%= link_to classroom_student_path(@classroom, student),
                       data: {
                         turbo_method: :delete,
                         turbo_confirm: "Are you sure you want to delete #{student.username}?"
                       },
-                      class: "tw-btn-danger" %>
+                      class: "inline-flex items-center justify-center w-8 h-8 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-lg transition-all duration-150 group",
+                      title: "Delete student" do %>
+                    <i class="fa fa-trash fa-lg group-hover:scale-110 transition-transform duration-150"></i>
+                  <% end %>
                 </div>
               </td>
             <% end %>

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -7,16 +7,27 @@
     <%= render @classroom %>
     <%= render 'classroom_students_table', students: @classroom.users %>
 
-    <% if policy(Classroom).edit? %>
-      <%= link_to "Edit this classroom", edit_classroom_path(@classroom),
-        class: "tw-btn-tertiary" %>
-    <% end %>
-    <% if policy(Classroom).destroy? %>
-      <div class="inline-block ml-2">
-        <%= button_to "Destroy this classroom", classroom_path(@classroom), method: :delete,
-          class: "tw-btn-danger" %>
+    <!-- Classroom Actions Section -->
+    <% if policy(Classroom).edit? || policy(Classroom).destroy? %>
+      <div class="mt-8 pt-6 border-t border-gray-200">
+        <div class="flex items-center justify-between">
+          <h3 class="text-lg font-medium text-gray-900">Classroom Actions</h3>
+          <div class="flex items-center gap-3">
+            <% if policy(Classroom).edit? %>
+              <%= link_to "Edit Classroom", edit_classroom_path(@classroom),
+                class: "tw-btn-tertiary" %>
+            <% end %>
+            <% if policy(Classroom).destroy? %>
+              <%= button_to "Delete Classroom", classroom_path(@classroom),
+                method: :delete,
+                data: { confirm: "Are you sure you want to delete this classroom? This action cannot be undone." },
+                class: "tw-btn-danger" %>
+            <% end %>
+          </div>
+        </div>
       </div>
     <% end %>
+
     <!-- Temporary UI, remove when tabbed table is wired up: -->
     <%= render "grade_books_list", grade_books: @classroom.grade_books %>
   </div>


### PR DESCRIPTION
## Changes
-  Replace Edit/Delete text links with FontAwesome icons (`fa-pencil`, `fa-trash`, `fa-key`)
-  Add hover effects and color-coded actions for better UX
-  Improve button styling and table spacing
-  Better organize `classroom` action buttons

## Testing
- [x] All functionality preserved
- [x] Icons match existing design patterns
- [x] RuboCop passes with no new offenses

Resolves #499