### PR TITLE
#462 classroom grade is numeric

### DIFF
--- a/app/dashboards/classroom_dashboard.rb
+++ b/app/dashboards/classroom_dashboard.rb
@@ -15,6 +15,10 @@ class ClassroomDashboard < Administrate::BaseDashboard
       searchable: false,
       collection: %w[5th 6th 7th 8th 9th 10th 11th 12th]
     ),
+    grade_numeric: Field::Select.with_options(
+      searchable: false,
+      collection: [5, 6, 7, 8, 9, 10, 11, 12]
+    ),
     name: Field::String,
     school_year: Field::BelongsTo,
     school: Field::HasOne,
@@ -55,6 +59,7 @@ class ClassroomDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     grade
+    grade_numeric
     name
     school_year
     students

--- a/db/migrate/20250908131121_add_grade_numeric_to_classrooms.rb
+++ b/db/migrate/20250908131121_add_grade_numeric_to_classrooms.rb
@@ -1,0 +1,5 @@
+class AddGradeNumericToClassrooms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :classrooms, :grade_numeric, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_103019) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_131441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_103019) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "school_year_id"
+    t.integer "grade_numeric"
     t.index ["school_year_id"], name: "index_classrooms_on_school_year_id"
   end
 

--- a/db/seeds/partials/classrooms.rb
+++ b/db/seeds/partials/classrooms.rb
@@ -1,1 +1,1 @@
-Classroom.find_or_create_by(name: "Smith's Sixth Grade", school_year: SchoolYear.first)
+Classroom.find_or_create_by(name: "Smith's Sixth Grade", school_year: SchoolYear.first, grade: '6th', grade_numeric: 6)

--- a/test/factories/classrooms.rb
+++ b/test/factories/classrooms.rb
@@ -3,6 +3,8 @@
 FactoryBot.define do
   factory :classroom do
     sequence(:name) { |n| "Classroom #{n}" }
+    sequence(:grade) { |n| "#{n}th" }
+    sequence(:grade_numeric) { |n| n }
     association :school_year
   end
 end


### PR DESCRIPTION
it resolves https://github.com/rubyforgood/stocks-in-the-future/issues/462

- Add new grade_numeric :integer field
- use this new grade_numeric field first
- then we can remove the grade string field and rename

<img width="800" height="546" alt="Screenshot 2025-09-08 at 15 22 51" src="https://github.com/user-attachments/assets/024dfe13-f92c-4234-94ec-40f7e154d005" />


Next steps are:
1. Migrate existing grade data to grade_numeric
2. Update forms/views to use grade_numeric
3. Remove old grade field and rename grade_numeric to grade