### PR TITLE
Add teacher name display and assignment to classrooms

### DIFF
--- a/app/assets/stylesheets/custom/buttons.css
+++ b/app/assets/stylesheets/custom/buttons.css
@@ -7,7 +7,7 @@
 }
 
 .tw-btn-primary {
-  @apply rounded-lg py-3 px-5 bg-[var(--sitf-primary-blue)] text-white block font-medium
+  @apply rounded-lg py-3 px-5 bg-[var(--sitf-primary-blue)] text-white block font-medium cursor-pointer hover:bg-blue-600 transition-colors
 }
 
 .tw-btn-secondary {

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -8,7 +8,7 @@ class ClassroomsController < ApplicationController
   before_action :check_classroom_eligibility, only: :show
 
   def index
-    @classrooms = policy_scope(Classroom).includes(students: :portfolio)
+    @classrooms = policy_scope(Classroom).includes(:teachers, students: :portfolio)
   end
 
   def show
@@ -66,7 +66,7 @@ class ClassroomsController < ApplicationController
   end
 
   def classroom_params
-    params.expect(classroom: %i[name grade school_id year_id])
+    params.expect(classroom: [:name, :grade, :school_id, :year_id, { teacher_ids: [] }])
   end
 
   def ensure_teacher_or_admin
@@ -76,6 +76,7 @@ class ClassroomsController < ApplicationController
   def dropdown_data
     @schools = School.order(:name)
     @years = Year.order(:name)
+    @teachers = Teacher.all.sort_by(&:display_name)
   end
 
   def assign_school_year_to_classroom

--- a/app/dashboards/classroom_dashboard.rb
+++ b/app/dashboards/classroom_dashboard.rb
@@ -34,6 +34,7 @@ class ClassroomDashboard < Administrate::BaseDashboard
     id
     grade
     name
+    teachers
     school_year
   ].freeze
 

--- a/app/views/classrooms/_form.html.erb
+++ b/app/views/classrooms/_form.html.erb
@@ -1,7 +1,9 @@
 <%= form_with(model: classroom, class: "contents") do |form| %>
   <% if classroom.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(classroom.errors.count, "error") %> prohibited this classroom from being saved:</h2>
+      <h2>
+        <%= pluralize(classroom.errors.count, "error") %> prohibited this classroom from being saved:
+      </h2>
 
       <ul>
         <% classroom.errors.each do |error| %>
@@ -22,7 +24,7 @@
     <%= form.label :school_id, "School Name", class: 'tw-label-primary' %>
     <div class="mt-2">
       <%= form.select :school_id,
-          options_from_collection_for_select(@schools, :id, :name, classroom&.school&.id),
+          options_from_collection_for_select(@schools, :id, :name, classroom&.school_year&.school&.id),
           { prompt: "Select a school" },
           { class: "tw-input-primary" } %>
     </div>
@@ -32,7 +34,7 @@
     <%= form.label :year_id, "Year", class: 'tw-label-primary' %>
     <div class="mt-2">
       <%= form.select :year_id,
-          options_from_collection_for_select(@years, :id, :name, classroom&.year&.id),
+          options_from_collection_for_select(@years, :id, :name, classroom&.school_year&.year&.id),
           { prompt: "Select a year" },
           { class: "tw-input-primary" } %>
     </div>
@@ -42,6 +44,46 @@
     <%= form.label :grade, class: 'tw-label-primary' %>
     <div class="mt-2">
       <%= form.text_field :grade, class: "tw-input-primary" %>
+    </div>
+  </div>
+
+  <div class="my-5">
+    <%= label_tag :teacher_ids, "Teachers", class: 'tw-label-primary flex items-center gap-2' %>
+
+    <!-- Single hidden field to handle empty selections -->
+    <%= hidden_field_tag "classroom[teacher_ids][]", "" %>
+
+    <div class="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 max-h-60 overflow-y-auto p-2 border border-gray-200 rounded-lg bg-gray-50">
+      <% @teachers.each do |teacher| %>
+        <%
+          # Check if teacher is assigned to this classroom
+          is_checked = classroom.persisted? ? classroom.teachers.include?(teacher) : false
+        %>
+
+        <label class="flex items-start gap-2 p-3 hover:bg-white rounded-lg cursor-pointer transition-colors">
+          <%= check_box_tag "classroom[teacher_ids][]",
+              teacher.id,
+              is_checked,
+              {
+                class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500 mt-0.5",
+                id: "classroom_teacher_ids_#{teacher.id}"
+              } %>
+
+          <div class="flex items-start gap-2 min-w-0 flex-1">
+            <div class="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-medium flex-shrink-0 mt-1">
+              <%= teacher.display_name.first.upcase %>
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="text-gray-900 font-medium truncate">
+                <%= teacher.display_name %>
+              </div>
+              <div class="text-xs text-gray-500 truncate">
+                @<%= teacher.email %>
+              </div>
+            </div>
+          </div>
+        </label>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -1,12 +1,15 @@
 <div class="flex flex-col h-full w-full">
   <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice">
+      <%= notice %>
+    </p>
   <% end %>
 
   <header class="flex items-center justify-between px-6 py-4 border-b">
     <h1 class="text-2xl font-bold">Classrooms</h1>
     <% if policy(Classroom).new? %>
-      <%= link_to "New classroom", new_classroom_path, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+      <%= link_to "New classroom", new_classroom_path,
+          class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
     <% end %>
   </header>
 
@@ -16,6 +19,9 @@
         <tr class="table-header-row">
           <th class="table-header-cell table-header-cell-left">
             Name
+          </th>
+          <th class="table-header-cell table-header-cell-left">
+            Teacher(s)
           </th>
           <th class="table-header-cell table-header-cell-left">
             Student Count
@@ -40,6 +46,23 @@
                   <%= classroom.name %>
                 </span>
               </td>
+              <td class="table-body-cell py-4">
+                <div class="flex gap-1 overflow-x-auto py-1" style="max-width: 510px; min-height: 36px;">
+                  <% if classroom.teachers.any? %>
+                    <% classroom.teachers.each do |teacher| %>
+                      <span class="inline-flex items-center px-2.5 py-1.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200 whitespace-nowrap flex-shrink-0">
+                        <i class="fas fa-user-tie mr-1 text-blue-600"></i>
+                        <%= teacher.display_name %>
+                      </span>
+                    <% end %>
+                  <% else %>
+                    <span class="inline-flex items-center px-2.5 py-1.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500 border border-gray-200 whitespace-nowrap">
+                      <i class="fas fa-user-slash mr-1 text-gray-400"></i>
+                      No teacher assigned
+                    </span>
+                  <% end %>
+                </div>
+              </td>
               <td class="table-body-cell">
                 <span class="table-cell-content">
                   <%= classroom.students.count %>
@@ -52,15 +75,34 @@
               </td>
               <td class="table-body-cell table-body-cell-center">
                 <% if policy(classroom).edit? %>
-                  <%= render partial: "components/action_icon_button", locals: { options: { path: edit_classroom_path(classroom), icon: "fa-pencil", title: "Edit classroom", aria_label: "Edit classroom", text_class: "text-blue-600" } } %>
-
+                  <%= render partial: "components/action_icon_button",
+                      locals: {
+                        options: {
+                          path: edit_classroom_path(classroom),
+                          icon: "fa-pencil",
+                          title: "Edit classroom",
+                          aria_label: "Edit classroom",
+                          text_class: "text-blue-600"
+                        }
+                      } %>
                 <% else %>
                   <span class="table-no-permission">-</span>
                 <% end %>
               </td>
               <td class="table-body-cell table-body-cell-center">
                 <% if policy(classroom).destroy? %>
-                  <%= render partial: "components/action_icon_button", locals: { options: { path: classroom_path(classroom), icon: "fa-trash", title: "Delete classroom", aria_label: "Delete classroom", text_class: "text-red-600", method: :delete, data: { turbo_confirm: "Are you sure you want to delete this classroom?" } } } %>
+                  <%= render partial: "components/action_icon_button",
+                      locals: {
+                        options: {
+                          path: classroom_path(classroom),
+                          icon: "fa-trash",
+                          title: "Delete classroom",
+                          aria_label: "Delete classroom",
+                          text_class: "text-red-600",
+                          method: :delete,
+                          data: { turbo_confirm: "Are you sure you want to delete this classroom?" }
+                        }
+                      } %>
                 <% else %>
                   <span class="table-no-permission">-</span>
                 <% end %>
@@ -69,7 +111,7 @@
           <% end %>
         <% else %>
           <tr class="table-body-row">
-            <td class="table-empty-cell" colspan="5">
+            <td class="table-empty-cell" colspan="6">
               <p class="text-lg">No classrooms found</p>
               <p class="mt-2">Create your first classroom to get started!</p>
             </td>


### PR DESCRIPTION
## Add teacher column to classrooms table

Display teacher in classroom table and make it selectable in the edit form (see #508).

### Changes
- Add teacher selection with checkboxes in classroom form
- Display assigned teachers as badges in classroom index table
- Eager load teacher associations to prevent N+1 queries
- Update admin dashboard to include teachers column
- Handle empty teacher assignments gracefully

### Screenshots
<img width="200" alt="Screen Shot 1404-06-18 at 17 48 06" src="https://github.com/user-attachments/assets/ff685f60-bf5c-4fb7-bff4-8dabde8b5f9f" />  
<img width="200" alt="Screen Shot 1404-06-18 at 17 48 24" src="https://github.com/user-attachments/assets/d1cd2c6c-80f4-4baa-b6aa-d99b18a9b7fd" />  
<img width="200" alt="Screen Shot 1404-06-18 at 17 48 32" src="https://github.com/user-attachments/assets/57a800f8-81d7-4ba3-b585-06c18af08a88" />  

---

Closes #508