### PR TITLE
465 Change display for `Student` and `Teacher` resources.

### DIFF
--- a/app/dashboards/student_dashboard.rb
+++ b/app/dashboards/student_dashboard.rb
@@ -67,8 +67,7 @@ class StudentDashboard < Administrate::BaseDashboard
 
   # Overwrite this method to customize how students are displayed
   # across all pages of the admin dashboard.
-  #
-  # def display_resource(student)
-  #   "Student ##{student.id}"
-  # end
+  def display_resource(student)
+    student.username
+  end
 end

--- a/app/dashboards/teacher_dashboard.rb
+++ b/app/dashboards/teacher_dashboard.rb
@@ -63,8 +63,7 @@ class TeacherDashboard < Administrate::BaseDashboard
 
   # Overwrite this method to customize how teachers are displayed
   # across all pages of the admin dashboard.
-  #
-  # def display_resource(teacher)
-  #   "Teacher ##{teacher.id}"
-  # end
+  def display_resource(teacher)
+    teacher.username
+  end
 end


### PR DESCRIPTION
Fixes #465 

Wherever a `Student` or `Teacher` resource is displayed, their username will be displayed instead of their id. This implements the request in the issue to change how these resources are displayed in select elements, and also in a few other logical places like the title of an edit form. I think this implementation makes sense, but if we only want the change to apply to the selects on this classroom edit page I can change the approach.


<details>
<summary>Before changes</summary>

  <img width="807" height="479" alt="image" src="https://github.com/user-attachments/assets/a65fdaf7-24e8-410b-b18f-bb076a213116" />
</details>

<details>
<summary>After changes</summary>

  <img width="806" height="464" alt="image" src="https://github.com/user-attachments/assets/defc390c-9128-4df4-9c9f-2b507dba474e" />
</details>