### PR TITLE
Add navigation links to classroom index page

### DIFF
--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -43,7 +43,7 @@
             <tr class="table-body-row">
               <td class="table-body-cell">
                 <span class="table-cell-content">
-                  <%= classroom.name %>
+                  <%= link_to classroom.name, classroom_path(classroom) %>
                 </span>
               </td>
               <td class="table-body-cell py-4">

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -255,4 +255,13 @@ class ClassroomsControllerTest < ActionDispatch::IntegrationTest
       assert_select "option[value='#{year.id}'][selected='selected']", text: year.name
     end
   end
+
+  test "index page includes link to classroom show page" do
+    sign_in(@admin)
+    classroom = create(:classroom, name: "Linked Class")
+
+    get classrooms_path
+    assert_response :success
+    assert_select "a[href='#{classroom_path(classroom)}']", text: "Linked Class"
+  end
 end


### PR DESCRIPTION
- Wrap classroom names with link_to to enable navigation to show pages.
- Add regression test to prevent future link removal.

Fixes #498