### PR TITLE
Fix: Update README to Remove Seeded User Emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ It is **strongly** recommend to use Docker. See instructions above.
 
 After running `bin/rails db:setup`, the database will automatically be seeded with three default users.
 
-| Role    | Username | Email                  | Password |
-|---------|----------|------------------------|----------|
-| Teacher | Teacher  | teacher@example.com    | password |
-| Student | Student  | student@example.com    | password |
-| Admin   | Admin    | admin@example.com      | password |
+| Role    | Username | Password |
+|---------|----------|----------|
+| Teacher | Teacher  | password |
+| Student | Student  | password |
+| Admin   | Admin    | password |
 
 Use the **username** and **password** to log in and test the application locally.
 


### PR DESCRIPTION
The README listed the emails with the seeded user accounts, however the application expects the username and not the email. Since we don't actually need the emails to sign in this extra information causes confusion. Removing these email will help with onboarding new devs.