### PR TITLE
Make header bar full size and move logo left

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
   </head>
   <body class="h-screen w-screen overflow-hidden">
     <% if user_signed_in? %>
-<<<<<<< HEAD
       <div class="fixed top-0 left-0 w-full z-50 flex items-center py-4 px-6 h-16 bg-[#f7f9f3]">
         <%= image_tag "SITF-Horz-no-tag-logo.svg", class: "h-8 w-auto", alt: "Stocks in The Future" %>
       </div>


### PR DESCRIPTION
Closes [559](https://github.com/rubyforgood/stocks-in-the-future/issues/559)

<img width="1440" height="675" alt="Screenshot 2025-09-12 at 6 16 54 PM" src="https://github.com/user-attachments/assets/57bb9460-2fe7-4589-85e9-069cfac98030" />
