### PR TITLE
Fix ExecuteOrder and seed data issues -- WIP

### DIFF
--- a/app/services/execute_order.rb
+++ b/app/services/execute_order.rb
@@ -44,7 +44,7 @@ class ExecuteOrder
     share_amount = order.sell? ? -shares : shares
     @portfolio_stock = portfolio
                        .portfolio_stocks
-                       .create!(stock:, shares: share_amount, purchase_price: stock_price_cents)
+                       .create!(stock:, shares: share_amount, purchase_price: stock.current_price)
   end
 
   def update_order_status

--- a/db/seeds/partials/orders.rb
+++ b/db/seeds/partials/orders.rb
@@ -7,7 +7,7 @@ mike = User.find_by(email: "mike@example.com")
 students = [student, mike].compact
 
 if students.any?
-  stocks = Stock.limit(5)
+  stocks = Stock.where.not(price_cents: nil).limit(5)
 
   students.each do |student_user|
     if student_user&.portfolio
@@ -88,7 +88,7 @@ end
 
 # Canceled orders
 if students.any?
-  stocks = Stock.limit(5)
+  stocks = Stock.where.not(price_cents: nil).limit(5)
   
   students.each do |student_user|
     if student_user&.portfolio

--- a/db/seeds/partials/orders.rb
+++ b/db/seeds/partials/orders.rb
@@ -7,7 +7,7 @@ mike = User.find_by(email: "mike@example.com")
 students = [student, mike].compact
 
 if students.any?
-  stocks = Stock.where.not(price_cents: nil).limit(5)
+  stocks = Stock.limit(5)
 
   students.each do |student_user|
     if student_user&.portfolio
@@ -17,6 +17,7 @@ if students.any?
         2.times do |i|
           stock = stocks[i]
           if stock
+            next unless stock.price_cents
             shares = 1
             cost = stock.price_cents / 100.0
 
@@ -88,7 +89,7 @@ end
 
 # Canceled orders
 if students.any?
-  stocks = Stock.where.not(price_cents: nil).limit(5)
+  stocks = Stock.limit(5)
   
   students.each do |student_user|
     if student_user&.portfolio

--- a/db/seeds/partials/portfolio_transactions.rb
+++ b/db/seeds/partials/portfolio_transactions.rb
@@ -11,10 +11,11 @@ if mike
     amount_cents: 15_000_00
   )
 
-  stocks = Stock.where.not(price_cents: nil).limit(3)
+  stocks = Stock.limit(3)
   shares = 2
 
   stocks.each do |stock|
+    next unless stock.price_cents
     total_price_cents = (stock.price_cents * shares)
 
     order = Order.create!(
@@ -31,6 +32,7 @@ if mike
   shares = 1
 
   stocks.each do |stock|
+    next unless stock.price_cents
     total_price_cents = (stock.price_cents * shares)
 
     order = Order.create!(
@@ -57,9 +59,10 @@ if mike
   )
 
   existing_stock_ids = Order.where(user: mike, action: :buy).pluck(:stock_id).uniq
-  stocks = Stock.where.not(id: existing_stock_ids).where.not(price_cents: nil).limit(1)
+  stocks = Stock.where.not(id: existing_stock_ids).limit(1)
 
   stocks.each do |stock|
+    next unless stock.price_cents
     shares = 1
     total_price_cents = (stock.price_cents * shares)
 

--- a/db/seeds/partials/portfolio_transactions.rb
+++ b/db/seeds/partials/portfolio_transactions.rb
@@ -11,7 +11,7 @@ if mike
     amount_cents: 15_000_00
   )
 
-  stocks = Stock.limit(3)
+  stocks = Stock.where.not(price_cents: nil).limit(3)
   shares = 2
 
   stocks.each do |stock|
@@ -57,7 +57,7 @@ if mike
   )
 
   existing_stock_ids = Order.where(user: mike, action: :buy).pluck(:stock_id).uniq
-  stocks = Stock.where.not(id: existing_stock_ids).limit(1)
+  stocks = Stock.where.not(id: existing_stock_ids).where.not(price_cents: nil).limit(1)
 
   stocks.each do |stock|
     shares = 1


### PR DESCRIPTION
- Fix ExecuteOrder to store purchase_price in dollars instead of cents
- Add nil price_cents checks to seed files to prevent seeding errors
- Ensures portfolio stocks have realistic purchase prices matching current price format

This fixes the massive profit/loss calculations caused by purchase prices being stored in cents while current prices are shown in dollars.
