### PR TITLE
removed New Order button from the Orders/Transactions page

### DIFF
--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,7 +5,6 @@
 
   <header class="flex items-center justify-between px-6 py-4 border-b">
     <h1 class="text-2xl font-bold">Transactions</h1>
-    <%= link_to "New Order", new_order_path, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
   </header>
 
   <main class="flex-1 p-6">


### PR DESCRIPTION
## What I did
- Removed the "New Order" button from the Orders page
- Verified tests pass after removal.

## Why I did it
- The "New Order" button is no longer needed since new orders should be made by buying/selling stock
- Removing it improves clarity for users and prevents confusion.

## How to test
1. Pull this branch.
2. Run the app locally (`bin/dev` or `docker compose up`).
3. Navigate to (http://localhost:3000/orders)
4. Confirm that the "New Order" button is no longer visible in the top right
5. Run test suite (`bin/rails test`) to confirm no issues.

## Notes
- No database changes required.
- All existing tests pass.
