### PR TITLE
Fix soft delete issues with discarded students

### DIFF
--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -12,7 +12,7 @@ class ClassroomsController < ApplicationController
   end
 
   def show
-    @students = @classroom.users.students.includes(:portfolio, :orders)
+    @students = @classroom.users.students.kept.includes(:portfolio, :orders)
     @can_manage_students = current_user.teacher_or_admin?
     @classroom_stats = calculate_classroom_stats if @can_manage_students
   end
@@ -91,7 +91,7 @@ class ClassroomsController < ApplicationController
   def calculate_classroom_stats
     return {} unless @classroom
 
-    students = @classroom.users.students
+    students = @classroom.users.students.kept
     {
       total_students: students.count,
       active_students: students.joins(:orders).distinct.count,

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -62,7 +62,9 @@ class StudentsController < ApplicationController
   end
 
   def set_student
-    @student = @classroom.users.students.find(params[:id])
+    @student = @classroom.users.students.kept.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to classroom_path(@classroom), alert: t("students.not_found")
   end
 
   def ensure_teacher_or_admin

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -12,7 +12,7 @@ class Classroom < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :teacher_classrooms, dependent: :destroy
   has_many :teachers, through: :teacher_classrooms
-  has_many :students, class_name: "Student", dependent: :nullify
+  has_many :students, -> { kept }, class_name: "Student", inverse_of: :classroom, dependent: :nullify
   has_many :grade_books, dependent: :nullify
 
   validates :name, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
       notice: Student updated successfully.
     add_transaction:
       success: "Transaction added to student successfully."
+    not_found: "Student not found"
   grade_books:
     finalize:
       incomplete: 'Cannot finalize: Some entries are incomplete.'

--- a/test/controllers/students_controller_test.rb
+++ b/test/controllers/students_controller_test.rb
@@ -161,4 +161,14 @@ class StudentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "teacher is redirected when accessing discarded student" do
+    sign_in @teacher
+    @student.discard
+
+    get classroom_student_path(@classroom, @student)
+
+    assert_redirected_to classroom_path(@classroom)
+    assert_match(/not found/i, flash[:alert])
+  end
 end

--- a/test/models/classroom_test.rb
+++ b/test/models/classroom_test.rb
@@ -91,4 +91,15 @@ class ClassroomTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::AssociationTypeMismatch) { classroom.teachers << student }
     assert_raises(ActiveRecord::AssociationTypeMismatch) { classroom.teachers << admin }
   end
+
+  test "students association excludes discarded students" do
+    classroom = create(:classroom)
+    kept_student = create(:student, classroom: classroom)
+    discarded_student = create(:student, classroom: classroom)
+    discarded_student.discard
+
+    assert_includes classroom.students, kept_student
+    assert_not_includes classroom.students, discarded_student
+    assert_equal [kept_student.id], classroom.students.pluck(:id)
+  end
 end


### PR DESCRIPTION
## Problem
After implementing soft delete, three issues remained:
1. Discarded students still showed on classroom pages
2. Clicking "Delete" on already-deleted students crashed the app
3. Classroom stats counted discarded students

## Changes
- `StudentsController#set_student` uses `.kept.find()` with error handling
- `ClassroomsController#show` and stats use `.kept` scope  
- `Classroom#students` association scoped to exclude discarded records
- Added `students.not_found` translation key
- Added unit and integration tests for discarded student scenarios
```ruby
# Model test: 
test "students association excludes discarded students"

# Controller test: 
test "teacher is redirected when accessing discarded student"
```
## Result
- Discarded students disappear from classroom pages immediately
- No more crashes when trying to delete already-deleted students
- Accurate classroom statistics
- User-friendly "Student not found" messages

Closes #596