### PR TITLE
Display "Available Funds" in Classroom Students Table

### DIFF
--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -12,7 +12,11 @@ class ClassroomsController < ApplicationController
   end
 
   def show
-    @students = @classroom.users.students.includes(:portfolio, :orders)
+    @students = @classroom.users.students.includes(
+      :portfolio, 
+      :orders,
+      portfolio: :portfolio_transactions
+    )
     @can_manage_students = current_user.teacher_or_admin?
     @classroom_stats = calculate_classroom_stats if @can_manage_students
   end

--- a/app/views/classrooms/_classroom_students_table.html.erb
+++ b/app/views/classrooms/_classroom_students_table.html.erb
@@ -20,6 +20,9 @@
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Portfolio</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Portfolio Value</th>
           <% if @can_manage_students %>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Available Funds</th>
+          <% end %>
+          <% if @can_manage_students %>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
           <% end %>
         </tr>
@@ -48,6 +51,15 @@
                 $0.00
               <% end %>
             </td>
+            <% if @can_manage_students %>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-medium">
+                <% if student.portfolio %>
+                  $<%= number_with_precision(student.portfolio.cash_balance, precision: 2) %>
+                <% else %>
+                  $0.00
+                <% end %>
+              </td>
+            <% end %>
             <% if @can_manage_students %>
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                 <div class="flex items-center gap-2">


### PR DESCRIPTION
### Problem
Teachers/Admins couldn't see how much cash students had available to invest - only portfolio value was shown.

### Changes
* Added "Available Funds" column showing cash balance (teachers/admins only)
* Included `portfolio: :portfolio_transactions` to prevent N+1 queries
* Uses existing `cash_balance` method, no schema changes

### Result
Teachers can now see exactly how much each student has to invest.

### How to test
1. Sign in as teacher/admin and visit `/classrooms/:id`
2. Verify new column shows student cash balances
3. Confirm students can't see this column
4. Check logs for no N+1 queries

Closes #569