### PR TITLE
Add Documentation for Orders, Transactions, and Gradebook Earnings

### DIFF
--- a/app/services/execute_order.rb
+++ b/app/services/execute_order.rb
@@ -30,7 +30,7 @@ class ExecuteOrder
     @portfolio_transaction = if order.buy?
                                portfolio
                                  .portfolio_transactions
-                                 .withdrawal
+                                 .debit
                                  .create!(amount_cents: purchase_cost)
                              else
                                portfolio

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,9 +12,9 @@ env :PATH, ENV.fetch("PATH", nil)
 
 # Run stock-related jobs at 1:00 AM Eastern Time every day
 every 1.day, at: "6:00 am" do
-  # Update stock prices first (external API call)
-  runner "StockPricesUpdateJob.perform_later"
-
-  # Then execute pending stock orders (internal processing)
+  # Execute pending stock orders at yesterdays price (internal processing)
   runner "OrderExecutionJob.perform_later"
+
+  # Then update stock prices (external API call)
+  runner "StockPricesUpdateJob.perform_later"
 end

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ app is built and evolves.
 - [Database seeds](seeds.md)
 - [Background job scheduling](scheduling.md)
 - [Schema](schema.md)
+- [Orders And Transactions](orders-and-transactions.md)
 - [Old site](old-site/README.md)
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ app is built and evolves.
 - [Background job scheduling](scheduling.md)
 - [Schema](schema.md)
 - [Orders And Transactions](orders-and-transactions.md)
+- [GradeBook Earnings](gradebook-earnings.md)
 - [Old site](old-site/README.md)
 
 ---

--- a/docs/gradebook-earnings.md
+++ b/docs/gradebook-earnings.md
@@ -1,0 +1,32 @@
+# GradeBook Earnings
+
+Students earn money in their portfolios through attendance and grades in their classes. This document outlines how these grade book earnings are calculated and recorded in the system.
+
+## Grade Book Structure
+- Each classroom has a grade book for each quarter of the school year.
+- At the end of each quarter, teachers and/or admins enter attendance and grades for each student in the classroom.
+  - *Note*: This grade book is only used to calculate earnings. This system is not responsible for individual grade management or report cards.
+- The following [entries](../app/models/grade_entry.rb) are supported for each student in the class for the grade book:
+  - Number of days attended
+  - Perfect Attendance (boolean)
+  - Reading Grade
+  - Math Grade
+
+## Earnings Calculation
+- Once grades have been entered, an admin can "finalize" the grade book for the quarter. This action will calculate earnings for each student based on their attendance and grades and create the corresponding transactions in their portfolios.
+- The earnings are calculated as follows:
+- Attendance:
+  - $0.20 per day attended
+  - $1.00 bonus for perfect attendance
+- Grades:
+  - Reading Grade in the A range: $3.00
+  - Reading Grade in the B range: $2.00
+  - Math Grade in the A range: $3.00
+  - Math Grade in the B range: $2.00
+- Grade Improvements
+  - If a student's grade improves from the previous quarter, they receive an additional bonus:
+    - Improvement in Reading Grade: $2.00
+    - Improvement in Math Grade: $2.00
+  - *Note* We currently are not looking at improvements across school years. So there are no improvement bonuses for the first quarter of a school year.
+
+See the [DistributeEarnings](../app/services/distribute_earnings.rb) class for the implementation of this logic.

--- a/docs/orders-and-transactions.md
+++ b/docs/orders-and-transactions.md
@@ -1,0 +1,40 @@
+# Orders and Transactions
+
+This document outlines how orders and transactions function in terms of this application. 
+Note that due to the fundamental way in which this system works, these concepts are different than you might typically expect from a stock trading platform.
+
+## [Orders](../app/models/order.rb)
+- Students can place buy or sell orders for stocks. These orders are not executed immediately but are pending until they are processed by the [OrderExecutionJob](../app/jobs/order_execution_job.rb) at the end of each day.
+  - Currently, this job runs a midnight Eastern Time.
+- Students can cancel or update their pending orders at any time before they have been executed.
+- At this time, orders can only be placed for whole shares of stock (no fractional shares).
+- When placing an order, the price of the stock is a known value. This is because we only update the stock prices once per day, and we execute all pending orders before updating the prices for the next day.
+
+### Transaction Fees
+- There is a flat transaction fee of $1.00 per student per day for executing orders, regardless of the number of orders placed.
+- Here are some examples: 
+  - A student places a buy order for 2 shares of stock A at $10 each. They will be charged $20 for the shares plus a $1 transaction fee, totaling $21.
+  - A student places buy orders for 1 share of stock A at $10 and 1 share of stock B at $15 on the same day. They will be charged $10 + $15 + $1 transaction fee, totaling $26.
+  - A student places a sell order for 3 shares of stock A at $10 each. They will receive $30 from the sale minus the $1 transaction fee, totaling $29.
+
+### Validations
+
+#### Buy Orders
+- When placing a buy order, the system checks if the student has sufficient cash in their portfolio to cover the cost of the shares plus the $1 transaction fee.
+  - Note that the system must correctly consider that multiple buy orders placed on the same day will incur only a single $1 transaction fee.
+  - The system also considers the total cost of all buy orders placed on that day when validating if the student has enough cash.
+  
+#### Sell Orders
+- When placing a sell order, the system checks if the student has enough shares of the stock they wish to sell in their portfolio.
+
+## [Transactions](../app/models/portfolio_transaction.rb) 
+- Transactions are records of cash movements in a student's portfolio.
+- Transactions can be of the following types:
+  - **Deposit** - represents cash added to the portfolio through earnings from gradebook or manual deposits by teachers/admins
+  - **Withdrawal** - represents cash removed from the portfolio by teachers/admins
+  - **Credit** - represents cash received from selling stocks
+  - **Debit** - represents cash spent on buying stocks
+  - **Fee** - represents the $1 transaction fee charged for executing orders
+- Transactions can be associated with an order if they are the result of executing a buy or sell order. However not every transaction is linked to an order (e.g., deposits, withdrawals, and fees).
+- Transactions are immutable records and should not be edited or deleted after they are created
+- Note that the transactions table is designed to be a ledger, thus if you want to calculate the current cash balance of a portfolio, you should sum up all the transactions. This is why the portfolios table does not have a cash balance column.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -6,8 +6,8 @@ This document explains how the stock-related jobs are scheduled to run automatic
 
 The application uses the `whenever` gem to schedule two jobs that run daily at 1:00 AM Eastern Time:
 
-1. **StockPricesUpdateJob** - Updates stock prices from Alpha Vantage API
-2. **OrderExecutionJob** - Executes pending stock orders (both buy and sell)
+1. **OrderExecutionJob** - Executes pending stock orders (both buy and sell)
+2. **StockPricesUpdateJob** - Updates stock prices from Alpha Vantage API
 
 ## Configuration
 
@@ -15,8 +15,8 @@ The scheduling configuration is defined in [`config/schedule.rb`](../config/sche
 
 ```ruby
 every 1.day, at: '1:00 am' do
-  runner "StockPricesUpdateJob.perform_later"
   runner "OrderExecutionJob.perform_later"
+  runner "StockPricesUpdateJob.perform_later"
 end
 ```
 
@@ -71,21 +71,6 @@ bundle exec whenever --clear-crontab
 # Or remove specific identifier
 bundle exec whenever --clear-crontab stocks-app
 ```
-
-### Capistrano Integration
-
-If using Capistrano for deployment, add the `whenever` gem integration:
-
-```ruby
-# Add to Gemfile
-gem 'whenever', require: false
-
-# Add to config/deploy.rb
-require 'whenever/capistrano'
-
-# The gem will automatically update crontab during deployment
-```
-
 ## Job Dependencies
 
 ### Prerequisites
@@ -121,12 +106,12 @@ For testing or emergency runs:
 ```bash
 # Run jobs manually in Rails console
 rails console
-StockPricesUpdateJob.perform_now
 OrderExecutionJob.perform_now
+StockPricesUpdateJob.perform_now
 
 # Or queue them
-StockPricesUpdateJob.perform_later
 OrderExecutionJob.perform_later
+StockPricesUpdateJob.perform_later
 ```
 
 ## Troubleshooting

--- a/test/services/execute_order_test.rb
+++ b/test/services/execute_order_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class ExecuteOrderTest < ActiveSupport::TestCase
-  test "it creates a withdrawal transaction in portfolio_transactions" do
+  test "it creates a debit transaction in portfolio_transactions" do
     student = create(:student)
     create(:portfolio, user: student)
     student.portfolio.portfolio_transactions.create!(amount_cents: 1000, transaction_type: :deposit)
@@ -15,7 +15,7 @@ class ExecuteOrderTest < ActiveSupport::TestCase
     end
 
     portfolio_transaction = PortfolioTransaction.last
-    assert portfolio_transaction.withdrawal?
+    assert portfolio_transaction.debit?
     assert_equal portfolio_transaction, order.portfolio_transaction
     assert_operator portfolio_transaction.amount_cents, :>, 0
   end


### PR DESCRIPTION
This pull request introduces several documentation improvements and a small but important change to the way portfolio transactions are recorded for buy orders. The documentation updates clarify how orders, transactions, gradebook earnings, and job scheduling work within the application. The code change updates the transaction type for buy orders to better reflect their purpose. Test coverage is updated to match this change.

**Documentation Enhancements**

* Added new documentation files: `orders-and-transactions.md` and `gradebook-earnings.md`, explaining how orders, transactions, and gradebook-based earnings work in the system. These provide clear details on transaction types, order processing, and earnings calculations. [[1]](diffhunk://#diff-c2c894b0e9e6fb21ee96d6713ea1ea33835a276c04da2f78a68b8fab3572e7d6R1-R40) [[2]](diffhunk://#diff-f20927128bfb5ebc5304c050f438178d8c829061d0e7005be3eddfffe8954b52R1-R32)
* Updated `README.md` to include links to the new documentation files for easier navigation.
* Improved `scheduling.md` to clarify the order of scheduled jobs, matching the actual execution sequence, and removed outdated Capistrano integration instructions. Also updated manual job execution instructions for accuracy. [[1]](diffhunk://#diff-5a20a064d617d410d31a1101b0ce7dfbcd91b81f40a872b7eadc238f8d409947L9-R19) [[2]](diffhunk://#diff-5a20a064d617d410d31a1101b0ce7dfbcd91b81f40a872b7eadc238f8d409947L74-L88) [[3]](diffhunk://#diff-5a20a064d617d410d31a1101b0ce7dfbcd91b81f40a872b7eadc238f8d409947L124-R114)

**Order Execution and Transaction Logic**

* Changed the transaction type created when executing a buy order from `withdrawal` to `debit` in `execute_order.rb`, ensuring transactions accurately represent cash spent on stock purchases.
* Updated related test in `execute_order_test.rb` to verify that a `debit` transaction is created for buy orders, maintaining correct test coverage. [[1]](diffhunk://#diff-52e7f6966a2f7e8644de8e451bd65e6770bd21eca4c3a0ae6bc723741e3c566fL6-R6) [[2]](diffhunk://#diff-52e7f6966a2f7e8644de8e451bd65e6770bd21eca4c3a0ae6bc723741e3c566fL18-R18)

**Job Scheduling**

* Reordered job execution in `config/schedule.rb` so that pending orders are executed before stock prices are updated, reflecting the intended business logic and documentation.