### PR TITLE
adds bin/coverage description to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ If you have any questions about an issue, comment on the issue, open a new issue
    $ bin/rails test
    ```
 
+   To check test coverage, run:
+
+   ```console
+   $ bin/coverage
+   ```
+
+   This generates an HTML coverage report at `coverage/index.html`
+
 6. **Push your branch** to GitHub
 
    ```console


### PR DESCRIPTION
It adds `bin/coverage` to the README as documentation. 

It's a follow-up ticket for https://github.com/rubyforgood/stocks-in-the-future/pull/623

The main issue is https://github.com/rubyforgood/stocks-in-the-future/issues/456