### PR TITLE
Run All Linters In CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: RuboCop
+name: Lint
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  rubocop:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,5 +25,5 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: Run RuboCop
-      run: bundle exec rubocop
+    - name: Run Lint
+      run: bin/lint

--- a/bin/lint
+++ b/bin/lint
@@ -10,7 +10,7 @@ if [[ "${CI:-}" == "true" ]]; then
 fi
 
 bundle exec i18n-tasks check-normalized
-bundle exec standardrb --parallel -f "$FORMATTER"
+bundle exec rubocop -f "$FORMATTER"
 
 echo ""
 echo "🎉 All checks passed!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,16 +19,20 @@ en:
     portfolio_path:
       index:
         portfolio: Portfolio
+  grade_books:
+    finalize:
+      incomplete: 'Cannot finalize: Some entries are incomplete.'
+      notice: Grade book finalized. Funds have been distributed.
   helpers:
     label:
       student:
         portfolio_path: Portfolio Link
   orders:
     cancel:
-      unauthorized: You can only cancel your own orders
-      success: Order was successfully canceled
-      pending_only: Only pending orders can be canceled
       confirm: Are you sure you want to cancel this order? This action cannot be undone.
+      pending_only: Only pending orders can be canceled
+      success: Order was successfully canceled
+      unauthorized: You can only cancel your own orders
     create:
       notice: Order was successfully created.
     destroy:
@@ -43,23 +47,19 @@ en:
     update:
       notice: School was successfully updated.
   students:
+    add_transaction:
+      success: Transaction added to student successfully.
     create:
       notice: 'Student %{username} created successfully. Initial password: %{password}'
     destroy:
       notice: Student %{username} deleted successfully.
     generate_password:
       notice: 'New password generated for %{username}: %{password}'
+    not_found: Student not found
     reset_password:
       notice: 'Password reset for %{username}. New password: %{password}'
     update:
       notice: Student updated successfully.
-    add_transaction:
-      success: "Transaction added to student successfully."
-    not_found: "Student not found"
-  grade_books:
-    finalize:
-      incomplete: 'Cannot finalize: Some entries are incomplete.'
-      notice: 'Grade book finalized. Funds have been distributed.'
   teachers:
     create:
       notice: Teacher created successfully. An account setup email has been sent.


### PR DESCRIPTION
This PR fixes the `bin/lint` script and uses it as part of our CI workflow. `bundle exec i18n-tasks normalize` was also ran to normalize our locales.