### PR TITLE
624 school year cannot be deleted if it has associations

### DIFF
--- a/app/models/school_year.rb
+++ b/app/models/school_year.rb
@@ -3,6 +3,6 @@
 class SchoolYear < ApplicationRecord
   belongs_to :school
   belongs_to :year
-  has_many :classrooms, dependent: :destroy
-  has_many :quarters, dependent: :destroy
+  has_many :classrooms, dependent: :restrict_with_error
+  has_many :quarters, dependent: :restrict_with_error
 end

--- a/test/models/school_year_test.rb
+++ b/test/models/school_year_test.rb
@@ -17,7 +17,7 @@ class SchoolYearTest < ActiveSupport::TestCase
     create(:classroom, school_year: school_year)
 
     assert_not school_year.destroy
-    assert_includes school_year.errors[:base], "Cannot delete record because dependent classrooms exist"
+    assert school_year.errors.added?(:base, "Cannot delete record because dependent classrooms exist")
   end
 
   test "cannot be destroyed when quarters exist" do
@@ -25,6 +25,6 @@ class SchoolYearTest < ActiveSupport::TestCase
     create(:quarter, school_year: school_year)
 
     assert_not school_year.destroy
-    assert_includes school_year.errors[:base], "Cannot delete record because dependent quarters exist"
+    assert school_year.errors.added?(:base, "Cannot delete record because dependent quarters exist")
   end
 end

--- a/test/models/school_year_test.rb
+++ b/test/models/school_year_test.rb
@@ -6,4 +6,25 @@ class SchoolYearTest < ActiveSupport::TestCase
   test "factory" do
     assert build(:school_year).validate!
   end
+
+  test "can be destroyed when no associations exist" do
+    school_year = create(:school_year)
+    assert school_year.destroy
+  end
+
+  test "cannot be destroyed when classrooms exist" do
+    school_year = create(:school_year)
+    create(:classroom, school_year: school_year)
+
+    assert_not school_year.destroy
+    assert_includes school_year.errors[:base], "Cannot delete record because dependent classrooms exist"
+  end
+
+  test "cannot be destroyed when quarters exist" do
+    school_year = create(:school_year)
+    create(:quarter, school_year: school_year)
+
+    assert_not school_year.destroy
+    assert_includes school_year.errors[:base], "Cannot delete record because dependent quarters exist"
+  end
 end


### PR DESCRIPTION
It resolves https://github.com/rubyforgood/stocks-in-the-future/issues/624

prevent removalof the  school year with associations

## when I try to delete it with associations
<img width="800" height="300" alt="Screenshot 2025-09-24 at 22 30 15" src="https://github.com/user-attachments/assets/9eb7b757-c0b5-41fe-8857-cd805bae1c81" />
