### PR TITLE
Updated the Lint status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Continuous Integration](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/ci.yml/badge.svg)](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/ci.yml)
-[![RuboCop](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/rubocop.yml/badge.svg)](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/rubocop.yml)
+[![Lint](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/lint.yml/badge.svg)](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/lint.yml)
 [![Dependabot Updates](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/dependabot/dependabot-updates)
 
 # Requirements


### PR DESCRIPTION
The RuboCop badge stopped working because the associated file in .github/workflows was renamed.  This pull request updates the README.md file to reflect the new filename.  You can see what the repository would look like with this correction at https://github.com/jhsu802701/stocks-in-the-future/tree/fix-lint-badge .