### PR TITLE
639 adding portfolio position to aggregates portfolio_stocks

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -23,6 +23,10 @@ class Portfolio < ApplicationRecord
     portfolio_stocks.where(stock_id: stock_id).sum(:shares)
   end
 
+  def positions
+    PortfolioPosition.for_portfolio(self)
+  end
+
   def calculate_total_value_cents
     cash_on_hand_in_cents + holdings_value_cents
   end

--- a/app/models/portfolio_position.rb
+++ b/app/models/portfolio_position.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class PortfolioPosition
+  attr_reader :stock, :shares
+
+  delegate :current_price, :price_cents, :ticker, :yesterday_price, to: :stock, prefix: :stock
+
+  def initialize(stock:, shares:)
+    @stock = stock
+    @shares = shares
+  end
+
+  def current_value
+    shares * stock_current_price
+  end
+
+  def current_value_cents
+    shares * stock_price_cents
+  end
+
+  # TODO: how to handle when it's missing? NA?
+  def stock_previous_close
+    stock_yesterday_price || stock_current_price
+  end
+
+  def self.for_portfolio(portfolio)
+    portfolio
+      .portfolio_stocks
+      .joins(:stock)
+      .group(:stock)
+      .having("SUM(portfolio_stocks.shares) > 0")
+      .sum(:shares)
+      .map { |stock, total_shares| new(stock: stock, shares: total_shares) }
+  end
+end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -12,4 +12,8 @@ class Stock < ApplicationRecord
   def current_price
     price_cents.to_f / 100
   end
+
+  def yesterday_price
+    yesterday_price_cents.to_f / 100 if yesterday_price_cents
+  end
 end

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -51,16 +51,16 @@
             </tr>
           </thead>
           <tbody class="text-[14px]">
-            <% @portfolio.portfolio_stocks.each do |ps| %>
-              <% price = ps.stock.current_price %>
-              <% shares = ps.shares %>
-              <% previous_close = ps.stock.current_price %>
+            <% @portfolio.positions.each do |position| %>
+              <% price = position.stock_current_price %>
+              <% shares = position.shares %>
+              <% previous_close = position.stock_previous_close %>
               <% change_amount = previous_close ? (price - previous_close) : 0 %>
-              <% total_return_amount = shares * price %>
+              <% total_return_amount = position.current_value %>
               <tr class="border-t first:border-t-0 border-black/40">
                 <td class="py-4 pl-6 pr-4 align-middle">
                   <div class="flex items-center gap-3">
-                    <span class="font-medium"><%= ps.stock.ticker %></span>
+                    <span class="font-medium"><%= position.stock_ticker %></span>
                   </div>
                 </td>
                 <td class="py-4 px-4 align-middle"><%= shares %></td>

--- a/test/models/portfolio_position_test.rb
+++ b/test/models/portfolio_position_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PortfolioPositionTest < ActiveSupport::TestCase
+  test "current_value and current_value_cents calculation" do
+    stock = create(:stock, price_cents: 12_000)
+    position = PortfolioPosition.new(stock: stock, shares: 8)
+
+    assert_equal 960.0, position.current_value
+    assert_equal 96_000, position.current_value_cents
+  end
+
+  test "stock_previous_close returns yesterday_price when available" do
+    stock = create(:stock, price_cents: 15_000, yesterday_price_cents: 14_500)
+    position = PortfolioPosition.new(stock: stock, shares: 5)
+
+    assert_equal 145.0, position.stock_previous_close
+  end
+
+  test "stock_previous_close falls back to current_price when yesterday_price is nil" do
+    stock = create(:stock, price_cents: 15_000, yesterday_price_cents: nil)
+    position = PortfolioPosition.new(stock: stock, shares: 5)
+
+    assert_equal 150.0, position.stock_previous_close
+  end
+
+  test "for_portfolio aggregates buy/sell transactions correctly" do
+    portfolio = create(:portfolio)
+    stock = create(:stock, ticker: "AAPL")
+
+    # Multiple buy/sell transactions: 10 + 5 - 3 = 12 shares
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 10)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 5)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: -3)
+
+    positions = PortfolioPosition.for_portfolio(portfolio)
+
+    assert_equal 1, positions.length
+    position = positions.first
+    assert_equal 12, position.shares
+    assert_equal stock, position.stock
+  end
+
+  test "for_portfolio excludes stocks with zero net holdings" do
+    portfolio = create(:portfolio)
+    stock1 = create(:stock, ticker: "ZERO")
+    stock2 = create(:stock, ticker: "POSITIVE")
+
+    # Stock with zero net holdings
+    create(:portfolio_stock, portfolio: portfolio, stock: stock1, shares: 10)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock1, shares: -10)
+
+    # Stock with positive holdings
+    create(:portfolio_stock, portfolio: portfolio, stock: stock2, shares: 5)
+
+    positions = PortfolioPosition.for_portfolio(portfolio)
+
+    assert_equal 1, positions.length
+    assert_equal "POSITIVE", positions.first.stock_ticker
+    assert_equal 5, positions.first.shares
+  end
+
+  test "for_portfolio returns empty array when no positive holdings" do
+    portfolio = create(:portfolio)
+    stock = create(:stock)
+
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 10)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: -10)
+
+    positions = PortfolioPosition.for_portfolio(portfolio)
+
+    assert_empty positions
+  end
+
+  test "for_portfolio handles complex trading scenarios" do
+    portfolio = create(:portfolio)
+    stock = create(:stock, ticker: "TSLA")
+
+    # Buy 100, buy 50, sell 30, buy 25, sell 20 = 125 net
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 100)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 50)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: -30)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 25)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: -20)
+
+    positions = PortfolioPosition.for_portfolio(portfolio)
+
+    assert_equal 1, positions.length
+    assert_equal 125, positions.first.shares
+  end
+end


### PR DESCRIPTION
It resolves https://github.com/rubyforgood/stocks-in-the-future/issues/639

- Create a new PortfolioPosition for aggregate view
- Use portfolio positions for showing holdings
- gain/loss in different ticket

From:
<img width="800" height="584" alt="Screenshot 2025-09-28 at 15 14 52" src="https://github.com/user-attachments/assets/ca0fd483-e3b5-40c0-bcc7-234373e654c5" />

To:
<img width="800" height="567" alt="image" src="https://github.com/user-attachments/assets/845f345e-20fc-4c5e-9d81-f46a9c3614cb" />
