### PR TITLE
Issue-660: smarter quarters to allow next and previous navigation across years

### DIFF
--- a/app/models/quarter.rb
+++ b/app/models/quarter.rb
@@ -11,10 +11,48 @@ class Quarter < ApplicationRecord
   scope :ordered, -> { order(:number) }
 
   def next
+    return first_quarter_of_next_year if number == 4
+
     school_year.quarters.ordered.find_by(number: number + 1)
   end
 
   def previous
+    return last_quarter_of_previous_year if number == 1
+
     school_year.quarters.ordered.find_by(number: number - 1)
+  end
+
+  private
+
+  def first_quarter_of_next_year
+    @first_quarter_of_next_year ||= begin
+      next_year = school_year.year.next_year
+
+      if next_year
+        Quarter.joins(school_year: %i[school year])
+               .where(
+                 school_years: { school: school_year.school },
+                 years: { id: next_year.id },
+                 number: 1
+               )
+               .first
+      end
+    end
+  end
+
+  def last_quarter_of_previous_year
+    @last_quarter_of_previous_year ||= begin
+      previous_year = school_year.year.previous_year
+
+      if previous_year
+        Quarter.joins(school_year: %i[school year])
+               .where(
+                 school_years: { school: school_year.school },
+                 years: { id: previous_year.id },
+                 number: 4
+               )
+               .first
+      end
+    end
   end
 end

--- a/app/models/year.rb
+++ b/app/models/year.rb
@@ -6,4 +6,26 @@ class Year < ApplicationRecord
   has_many :classrooms, through: :school_years
 
   validates :name, presence: true, uniqueness: true
+
+  def previous_year
+    @previous_year || Year.find_by(name: "#{start_year_value - 1} - #{start_year_value}")
+  end
+
+  def next_year
+    @next_year || Year.find_by(name: "#{end_year_value} - #{end_year_value + 1}")
+  end
+
+  private
+
+  def start_year_value
+    @start_year_value ||= parsed_year_values.first
+  end
+
+  def end_year_value
+    @end_year_value ||= parsed_year_values.last
+  end
+
+  def parsed_year_values
+    @parsed_year_values ||= name.split(" - ").map(&:to_i)
+  end
 end

--- a/test/models/quarter_test.rb
+++ b/test/models/quarter_test.rb
@@ -5,9 +5,9 @@ require "test_helper"
 
 class QuarterTest < ActiveSupport::TestCase
   test "factory is valid and assigns sequential numbers" do
-    school_year = create(:school_year)
-    q1 = create(:quarter, school_year: school_year, number: 1)
-    q2 = create(:quarter, school_year: school_year, number: 2)
+    school_year = build(:school_year)
+    q1 = build_stubbed(:quarter, school_year: school_year, number: 1)
+    q2 = build_stubbed(:quarter, school_year: school_year, number: 2)
     assert q1.valid?
     assert q2.valid?
     assert_equal 1, q1.number
@@ -15,21 +15,21 @@ class QuarterTest < ActiveSupport::TestCase
   end
 
   test "validates presence of number" do
-    quarter = build(:quarter, number: nil)
+    quarter = build_stubbed(:quarter, number: nil)
     assert_not quarter.valid?
     assert_includes quarter.errors[:number], "can't be blank"
   end
 
   test "validates inclusion of number in 1..4" do
     %w[0 5 10].each do |bad|
-      quarter = build(:quarter, number: bad.to_i)
+      quarter = build_stubbed(:quarter, number: bad.to_i)
       assert_not quarter.valid?, "#{bad} should be invalid"
       assert_includes quarter.errors[:number], "is not included in the list"
     end
   end
 
   test "validates uniqueness of number per school_year" do
-    school_year = create(:school_year)
+    school_year = build(:school_year)
     create(:quarter, school_year: school_year, number: 1)
     dup = build(:quarter, school_year: school_year, number: 1)
     assert_not dup.valid?
@@ -37,19 +37,42 @@ class QuarterTest < ActiveSupport::TestCase
   end
 
   test "default scope orders by number" do
-    school_year = create(:school_year)
+    school_year = build(:school_year)
     create(:quarter, school_year: school_year, number: 3)
     create(:quarter, school_year: school_year, number: 1)
     assert_equal [1, 3], school_year.quarters.ordered.pluck(:number)
   end
 
   test "next and previous helpers" do
-    school_year = create(:school_year)
+    school_year = build(:school_year)
     q1 = create(:quarter, school_year: school_year, number: 1)
     q2 = create(:quarter, school_year: school_year, number: 2)
     assert_equal q2, q1.next
     assert_nil q1.previous
     assert_equal q1, q2.previous
     assert_nil q2.next
+  end
+
+  test "next and previous across school years" do
+    school = build(:school)
+    year1 = build(:year, name: "2023 - 2024")
+    year2 = build(:year, name: "2024 - 2025")
+    sy1 = build(:school_year, school: school, year: year1)
+    sy2 = build(:school_year, school: school, year: year2)
+
+    q4_y1 = create(:quarter, school_year: sy1, number: 4)
+    q1_y2 = create(:quarter, school_year: sy2, number: 1)
+
+    assert_equal q1_y2, q4_y1.next
+    assert_equal q4_y1, q1_y2.previous
+
+    # Edge cases where there is no next/previous year
+    year4 = build(:year, name: "2026 - 2027")
+    sy4 = build(:school_year, school: school, year: year4)
+    q1_y4 = create(:quarter, school_year: sy4, number: 1)
+    q4_y4 = create(:quarter, school_year: sy4, number: 4)
+
+    assert_nil q1_y4.previous
+    assert_nil q4_y4.next
   end
 end

--- a/test/models/year_test.rb
+++ b/test/models/year_test.rb
@@ -22,4 +22,19 @@ class YearTest < ActiveSupport::TestCase
     assert_not year.valid?
     assert year.errors.added?(:name, :taken, value: duplicate_year)
   end
+
+  test "previous_year and next_year" do
+    year_2022_2023 = create(:year, name: "2022 - 2023")
+    year_2023_2024 = create(:year, name: "2023 - 2024")
+    year_2024_2025 = create(:year, name: "2024 - 2025")
+
+    assert_nil year_2022_2023.previous_year
+    assert_equal year_2023_2024, year_2022_2023.next_year
+
+    assert_equal year_2022_2023, year_2023_2024.previous_year
+    assert_equal year_2024_2025, year_2023_2024.next_year
+
+    assert_equal year_2023_2024, year_2024_2025.previous_year
+    assert_nil year_2024_2025.next_year
+  end
 end

--- a/test/models/year_test.rb
+++ b/test/models/year_test.rb
@@ -24,17 +24,17 @@ class YearTest < ActiveSupport::TestCase
   end
 
   test "previous_year and next_year" do
-    year_2022_2023 = create(:year, name: "2022 - 2023")
-    year_2023_2024 = create(:year, name: "2023 - 2024")
-    year_2024_2025 = create(:year, name: "2024 - 2025")
+    year2022_to2023 = create(:year, name: "2022 - 2023")
+    year2023_to2024 = create(:year, name: "2023 - 2024")
+    year2024_to2025 = create(:year, name: "2024 - 2025")
 
-    assert_nil year_2022_2023.previous_year
-    assert_equal year_2023_2024, year_2022_2023.next_year
+    assert_nil year2022_to2023.previous_year
+    assert_equal year2023_to2024, year2022_to2023.next_year
 
-    assert_equal year_2022_2023, year_2023_2024.previous_year
-    assert_equal year_2024_2025, year_2023_2024.next_year
+    assert_equal year2022_to2023, year2023_to2024.previous_year
+    assert_equal year2024_to2025, year2023_to2024.next_year
 
-    assert_equal year_2023_2024, year_2024_2025.previous_year
-    assert_nil year_2024_2025.next_year
+    assert_equal year2023_to2024, year2024_to2025.previous_year
+    assert_nil year2024_to2025.next_year
   end
 end


### PR DESCRIPTION
## The Problem

The current `previous` and `next` methods **only work within the same school year**. They look for quarters with `number - 1` or `number + 1` within the same `school_year`.

**What happens now:**
- If you're in Q1 and call `previous`, it looks for Q0 (doesn't exist) → returns `nil`
- If you're in Q4 and call `next`, it looks for Q5 (doesn't exist) → returns `nil`

**What we need:**
- Q1 2022-2023 `previous` should return Q4 2021-2022
- Q4 2021-2022 `next` should return Q1 2022-2023

**The core issue:** There's no mechanism to navigate across different school years, even though quarters naturally flow from one school year to the next in a continuous sequence.

## Considerations
- Im lukewarm about using keywords like `next`. So I prefer `next_thing`. OTOH I also understand the value of consistency. I know `year.previous_year` looks strange. I can be easily convinced!

## Reference
Find details in [Issue 660](https://github.com/rubyforgood/stocks-in-the-future/issues/660)
