### PR TITLE
Add tailwind css to transaction type element on the admin student edit view (resolves #688)

### DIFF
--- a/app/assets/tailwind/admin.css
+++ b/app/assets/tailwind/admin.css
@@ -16,4 +16,6 @@
 
   .header-controls    { @apply flex items-center justify-between mb-4; }
   .action-buttons     { @apply flex gap-2; }
+
+  .form-select        { @apply w-full rounded-md border border-input bg-transparent p-2 text-sm; }
 }

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -74,7 +74,7 @@ and renders all form fields for a resource's editable attributes.
   <div class="field-unit">
     <div class="field-unit__label"><label for="student_transaction_type">Transaction Type</label></div>
     <div class="field-unit__field">
-      <select name="student[transaction_type]" id="student_transaction_type" aria-required="false">
+      <select name="student[transaction_type]" id="student_transaction_type" aria-required="false" class="w-full rounded-md border border-input bg-transparent p-2 text-sm">
         <% ["", "deposit", "debit"].each do |option| %>
           <option><%= option %></option>
         <% end %>

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -74,7 +74,7 @@ and renders all form fields for a resource's editable attributes.
   <div class="field-unit">
     <div class="field-unit__label"><label for="student_transaction_type">Transaction Type</label></div>
     <div class="field-unit__field">
-      <select name="student[transaction_type]" id="student_transaction_type" aria-required="false" class="w-full rounded-md border border-input bg-transparent p-2 text-sm">
+      <select name="student[transaction_type]" id="student_transaction_type" aria-required="false" class="form-select">
         <% ["", "deposit", "debit"].each do |option| %>
           <option><%= option %></option>
         <% end %>
@@ -90,7 +90,7 @@ and renders all form fields for a resource's editable attributes.
   <div class="field-unit">
     <div class="field-unit__label"><label for="student_transaction_reason">Reason</label></div>
     <div class="field-unit__field">
-      <select required name="student[transaction_reason]" id="student_transaction_reason" aria-required="true">
+      <select required name="student[transaction_reason]" id="student_transaction_reason" aria-required="true" class="form-select">
         <option value=""></option>
         <% PortfolioTransaction::REASONS.each do |key, label| %>
           <option value="<%= key %>"><%= label %></option>


### PR DESCRIPTION
Why?

The dropdown element is not visible on the student edit page. 

What?
Since most of the page looks like it's rendered by the administrate gem, I went ahead and just added some custom css to keep it in line with the other elements in its form.

Future changes:

I am not super familiar with this app yet so I just kept it simple for now, I imagine we would want to add some css for all select elements at a certain point. 