### PR TITLE
678 fixing css for actiontext

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -359,6 +359,12 @@ trix-editor .attachment__metadata {
     border-right-width: 0.3em;
     margin-right: 0.3em;
     padding-right: 0.6em; }
+  .trix-content ul {
+    list-style-type: disc;
+    padding-left: 1.5em; }
+  .trix-content ol {
+    list-style-type: decimal;
+    padding-left: 1.5em; }
   .trix-content li {
     margin-left: 1em; }
   .trix-content [dir=rtl] li {

--- a/app/views/admin/application/_stylesheet.html.erb
+++ b/app/views/admin/application/_stylesheet.html.erb
@@ -1,0 +1,15 @@
+<%#
+# Stylesheet Partial
+
+This partial imports the necessary stylesheets on each page.
+By default, it includes the application CSS,
+but each page can define additional CSS sources
+by providing a `content_for(:stylesheet)` block.
+%>
+
+<% Administrate::Engine.stylesheets.each do |css_path| %>
+  <%= stylesheet_link_tag css_path %>
+<% end %>
+<%= stylesheet_link_tag "actiontext", "data-turbo-track": "reload" %>
+
+<%= yield :stylesheet %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "actiontext", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   </head>


### PR DESCRIPTION
It resolves https://github.com/rubyforgood/stocks-in-the-future/issues/678

- adds actiontext css to the main layout
- adds actiontext css to the admin layout
- fixing ul/ol css in the actiontext

## screenshots

### Admin New/Edit

<img width="800" height="660" alt="image" src="https://github.com/user-attachments/assets/c75ea49e-0705-4b97-b3a7-6968b7cea183" />

### Admin Show

<img width="800" height="699" alt="image" src="https://github.com/user-attachments/assets/879b9206-976d-465a-abe1-63671b06d451" />

### Homepage

There is no formatting yet

<img width="800" height="234" alt="image" src="https://github.com/user-attachments/assets/a0b66fc4-c78e-4588-b683-da5707854399" />

### Show 

<img width="800" height="685" alt="image" src="https://github.com/user-attachments/assets/4e7727ed-cc5b-4f20-841f-dede586bb078" />



