### PR TITLE
Add color coding to Total Return column in portfolio table

### DIFF
--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -67,7 +67,9 @@
                 <td class="py-4 px-4 align-middle tabular-nums <%= change_amount >= 0 ? 'text-green-600' : 'text-red-600' %>">
                   <% if change_amount >= 0 %>+<% end %> <%= number_to_currency(change_amount) %>
                 </td>
-                <td class="py-4 px-4 align-middle tabular-nums"><%= number_to_currency(total_return_amount) %></td>
+                <td class="py-4 px-4 align-middle tabular-nums <%= total_return_amount >= 0 ? 'text-green-600' : 'text-red-600' %>">
+                  <% if total_return_amount >= 0 %>+<% end %> <%= number_to_currency(total_return_amount) %>
+                </td>
                 <td class="py-3 pr-6 align-middle">
                   <button class="inline-flex items-center justify-center rounded-full bg-sky-800 text-white px-6 py-2 text-sm font-medium shadow hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 transition-colors">Trade</button>
                 </td>


### PR DESCRIPTION
Added red/green color styling to the Total Return column to match the Change column. Positive returns show in green with a + prefix, negative returns show in red.

Fixes #684