### PR TITLE
616 toggle navbar trading floor

### DIFF
--- a/app/assets/tailwind/navbar.css
+++ b/app/assets/tailwind/navbar.css
@@ -87,3 +87,16 @@
 .animate-scroll {
   animation: scroll 20s linear infinite;
 }
+
+/* Trading Floor collapse chevron toggle */
+details .icon-up {
+  display: none;
+}
+
+details[open] .icon-down {
+  display: none;
+}
+
+details[open] .icon-up {
+  display: block;
+}

--- a/app/javascript/controllers/stock_navbar_toggle_controller.js
+++ b/app/javascript/controllers/stock_navbar_toggle_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  navigateLink(event) {
+    // Prevent the summary from toggling when clicking the link
+    event.stopPropagation()
+  }
+}

--- a/app/javascript/controllers/stocks_toggle_controller.js
+++ b/app/javascript/controllers/stocks_toggle_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  navigateLink(event) {
+    // Prevent the summary from toggling when clicking the link
+    event.stopPropagation()
+    // Let the link navigate normally
+  }
+}

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -59,33 +59,35 @@
             <% end %>
 
             <li>
-              <% is_active = request.path.include?('stocks') %>
-              <%= link_to stocks_path, class: "flex items-center justify-between px-3 py-2 rounded-lg w-full group hover:bg-black/20", style: is_active ? "background-color: #d3df44;" : "" do %>
-                <div class="flex gap-3 items-center">
-                  <div class="w-6 h-6">
-                    <%= image_tag "chart-no-axes-combined.svg", class: "w-6 h-6", style: "filter: brightness(0) saturate(100%) #{is_active ? 'invert(20%) sepia(8%) saturate(348%) hue-rotate(114deg) brightness(98%) contrast(85%)' : 'invert(100%)'}" %>
-                  </div>
-                  <span class="font-medium text-sm" style="color: <%= is_active ? '#323232' : 'white' %>; font-family: Inter, sans-serif;">Trading Floor</span>
-                </div>
-                <div class="w-4 h-4 flex items-center justify-center">
-                  <svg class="w-3 h-3" style="color: <%= is_active ? '#323232' : 'white' %>;" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                  </svg>
-                </div>
-              <% end %>
+              <details <%= 'open' if request.path.match?(/\/stocks\/\d+/) %> data-controller="stock-navbar-toggle">
+                <summary class="flex items-center justify-between px-3 py-2 rounded-lg w-full list-none <%= 'bg-[#d3df44]' if request.path.include?('stocks') %>" style="<%= request.path.include?('stocks') ? 'background-color: #d3df44;' : '' %>">
+                  <% is_active = request.path.include?('stocks') %>
+                  <%= link_to stocks_path, class: "flex gap-3 items-center flex-1 hover:opacity-80", data: { action: "click->stock-navbar-toggle#navigateLink" } do %>
+                    <div class="w-6 h-6">
+                      <%= image_tag "chart-no-axes-combined.svg", class: "w-6 h-6", style: "filter: brightness(0) saturate(100%) #{is_active ? 'invert(20%) sepia(8%) saturate(348%) hue-rotate(114deg) brightness(98%) contrast(85%)' : 'invert(100%)'}" %>
+                    </div>
+                    <span class="font-medium text-sm" style="color: <%= is_active ? '#323232' : 'white' %>; font-family: Inter, sans-serif;">Trading Floor</span>
+                  <% end %>
 
-              <div class="box-border content-stretch flex flex-col items-start justify-start p-[8px] relative w-full ml-6">
-                <% navbar_stocks.each do |stock| %>
-                  <div class="content-stretch flex items-center justify-start relative rounded-[16px] shrink-0 w-full">
-                    <% stock_active = request.path == stock_path(stock) %>
-                    <%= link_to stock_path(stock), class: "basis-0 box-border content-stretch flex gap-2 grow h-8 items-center justify-start min-h-px min-w-px p-[8px] relative rounded-[16px] shrink-0 hover:bg-black/20 hover:bg-black" do %>
-                      <div class="basis-0 font-['Geist',sans-serif] font-normal grow leading-[0] min-h-px min-w-px overflow-ellipsis overflow-hidden relative shrink-0 text-[14px] text-nowrap text-white <%= 'underline decoration-2 underline-offset-2' if stock_active %>">
-                        <p class="leading-none overflow-inherit"><%= stock.ticker %></p>
-                      </div>
-                    <% end %>
+                  <div class="w-4 h-4 flex items-center justify-center cursor-pointer hover:opacity-70">
+                    <i class="fa-solid fa-angle-down icon-down" style="color: <%= is_active ? '#323232' : 'white' %>;"></i>
+                    <i class="fa-solid fa-angle-up icon-up" style="color: <%= is_active ? '#323232' : 'white' %>;"></i>
                   </div>
-                <% end %>
-              </div>
+                </summary>
+
+                <div class="box-border content-stretch flex flex-col items-start justify-start p-[8px] relative w-full ml-6">
+                  <% navbar_stocks.each do |stock| %>
+                    <div class="content-stretch flex items-center justify-start relative rounded-[16px] shrink-0 w-full">
+                      <% stock_active = request.path == stock_path(stock) %>
+                      <%= link_to stock_path(stock), class: "basis-0 box-border content-stretch flex gap-2 grow h-8 items-center justify-start min-h-px min-w-px p-[8px] relative rounded-[16px] shrink-0 hover:bg-black/20 hover:bg-black" do %>
+                        <div class="basis-0 font-['Geist',sans-serif] font-normal grow leading-[0] min-h-px min-w-px overflow-ellipsis overflow-hidden relative shrink-0 text-[14px] text-nowrap text-white <%= 'underline decoration-2 underline-offset-2' if stock_active %>">
+                          <p class="leading-none overflow-inherit"><%= stock.ticker %></p>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              </details>
             </li>
 
           </ul>


### PR DESCRIPTION
It resolves https://github.com/rubyforgood/stocks-in-the-future/issues/616

- default state is closed
- open/close by Cheron
- stay open on each stock page

## screenshots

### 1. The default state is closed.

<img width="299" height="264" alt="image" src="https://github.com/user-attachments/assets/d110b583-0342-4b0d-b5c9-df9876e61272" />


### 2. The trading floor works as a link

<img width="593" height="463" alt="image" src="https://github.com/user-attachments/assets/3d5b034e-a299-49c5-abd6-5e982f200a7b" />


### 3. But you can open the list of stocks if you want

<img width="435" height="232" alt="image" src="https://github.com/user-attachments/assets/c3b034a4-bd3b-45af-868f-702ff18c3c11" />


### 4. It keeps it open if you select a stock.

<img width="615" height="421" alt="image" src="https://github.com/user-attachments/assets/93b73041-8707-400d-8fad-c55818d18156" />



