### PR TITLE
Add missing staging.rb seeds file so we can seed in staging

### DIFF
--- a/db/seeds/staging.rb
+++ b/db/seeds/staging.rb
@@ -1,0 +1,3 @@
+# Staging environment uses the same seeds as development
+puts "Staging environment detected - loading development seeds"
+load(Rails.root.join('db', 'seeds', 'development.rb'))


### PR DESCRIPTION
## Fix Heroku staging environment seeding error

### Problem
Heroku deployments to staging environment were failing when running `heroku rake db:seed` because we didn't have a staging file

### Changes
Added: db/seeds/staging.rb - loads development seeds for staging environment
We want all the sample data we have for development in staging so we can play around with it