### PR TITLE
Badgen's badges cache for 3600 seconds / 1 hour instead of 24h

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Lint](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/lint.yml/badge.svg)](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/lint.yml)
 [![Dependabot Updates](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/rubyforgood/stocks-in-the-future/actions/workflows/dependabot/dependabot-updates)
 
-[![Help wanted](https://badgen.net/github/label-issues/rubyforgood/stocks-in-the-future/help%20wanted/open??color=green&icon=github)](https://github.com/rubyforgood/stocks-in-the-future/labels/help%20wanted)
-[![Open PRs](https://badgen.net/github/open-prs/rubyforgood/stocks-in-the-future??color=green&icon=github)](https://github.com/rubyforgood/stocks-in-the-future/pulls)
-[![Last commit](https://badgen.net/github/last-commit/rubyforgood/stocks-in-the-future??icon=github)](https://github.com/rubyforgood/stocks-in-the-future/commits)
+[![Help wanted](https://badgen.net/github/label-issues/rubyforgood/stocks-in-the-future/help%20wanted/open??color=green&icon=github&cache=3600)](https://github.com/rubyforgood/stocks-in-the-future/labels/help%20wanted)
+[![Open PRs](https://badgen.net/github/open-prs/rubyforgood/stocks-in-the-future??color=green&icon=github&cache=3600)](https://github.com/rubyforgood/stocks-in-the-future/pulls)
+[![Last commit](https://badgen.net/github/last-commit/rubyforgood/stocks-in-the-future??icon=github&cache=3600)](https://github.com/rubyforgood/stocks-in-the-future/commits)
 
 # Requirements
 


### PR DESCRIPTION
No ticket

It updates the cache for the badges on Badgen.net's CDN. 

## Technical

Badgen.net's default cache in their CDN is 24 hours. 

I believe a 1-hour cache will be enough for us. But 24h is too much. 

We don't need more frequent updates for the badge. 

The whole point of the badges is to increase the visibility of help-wanted issues, open PR's, and the last commit for building more trust + activity.

## How to test?

<img width="692" height="311" alt="image" src="https://github.com/user-attachments/assets/dca94c36-15f5-4797-8714-dcb8c35025e9" />

https://github.com/rubyforgood/stocks-in-the-future/blob/240b3d3abe3a9e2a8d778fce6f9b933e0f6013d7/README.md 

