### PR TITLE
Add importmap audit to CI pipleline

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -13,6 +13,7 @@ bundle exec i18n-tasks check-normalized
 bundle exec rubocop -f "$FORMATTER"
 bin/brakeman --no-pager --exit-on-warn --quiet
 bin/bundler-audit check --update
+bin/importmap audit
 
 echo ""
 echo "🎉 All checks passed!"


### PR DESCRIPTION
Resolves #743 

This PR adds importmap audit to the CI. It did not detect any vulnerabilities.