### PR TITLE
Fix link color inconsistency

### DIFF
--- a/app/views/classrooms/_classroom_students_table.html.erb
+++ b/app/views/classrooms/_classroom_students_table.html.erb
@@ -30,7 +30,7 @@
             <td class="px-6 py-4 whitespace-nowrap">
               <% if student.username.present? %>
                 <% if student.portfolio %>
-                  <%= link_to student.username, user_portfolio_path(student, student.portfolio), class: "text-blue-600 hover:text-blue-900 font-medium" %>
+                  <%= link_to student.username, user_portfolio_path(student, student.portfolio), class: "text-black underline hover:text-[var(--sitf-secondary-chart2)] font-medium" %>
                 <% else %>
                   <span class="text-gray-400 italic"><%= student.username %></span>
                 <% end %>
@@ -50,7 +50,7 @@
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                 <div class="flex items-center gap-2">
                   <%= link_to edit_classroom_student_path(@classroom, student),
-                      class: "inline-flex items-center justify-center w-8 h-8 text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded-lg transition-all duration-150 group",
+                      class: "inline-flex items-center justify-center w-8 h-8 text-black hover:text-[var(--sitf-secondary-chart2)] hover:bg-blue-50 rounded-lg transition-all duration-150 group",
                       title: "Edit student" do %>
                     <i class="fa fa-pencil fa-lg group-hover:scale-110 transition-transform duration-150"></i>
                   <% end %>

--- a/app/views/classrooms/_grade_books_list.html.erb
+++ b/app/views/classrooms/_grade_books_list.html.erb
@@ -7,7 +7,7 @@
         <li class="px-6 py-4 hover:bg-gray-50">
           <%= link_to book.quarter.name,
                       classroom_grade_book_path(@classroom, book),
-                      class: "text-indigo-600 hover:text-indigo-900 font-medium" %>
+                      class: "text-black underline hover:text-[var(--sitf-secondary-chart2)] font-medium" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -43,7 +43,7 @@
             <tr class="table-body-row">
               <td class="table-body-cell">
                 <span class="table-cell-content">
-                  <%= link_to classroom.name, classroom_path(classroom), class: "text-blue-600 hover:text-blue-800" %>
+                  <%= link_to classroom.name, classroom_path(classroom), class: "text-black underline hover:text-[var(--sitf-secondary-chart2)]" %>
                 </span>
               </td>
               <td class="table-body-cell py-4">
@@ -82,7 +82,7 @@
                           icon: "fa-pencil",
                           title: "Edit classroom",
                           aria_label: "Edit classroom",
-                          text_class: "text-blue-600"
+                          text_class: "text-black"
                         }
                       } %>
                 <% else %>

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -19,7 +19,7 @@
           <h3 class="text-lg font-medium text-gray-900">Classroom Actions</h3>
           <div class="flex items-center gap-3">
             <% if policy(Classroom).edit? %>
-              <%= render partial: "components/action_icon_button", locals: { options: { path: edit_classroom_path(@classroom), icon: "fa-pencil", title: "Edit classroom", aria_label: "Edit classroom", text_class: "text-blue-600" } } %>
+              <%= render partial: "components/action_icon_button", locals: { options: { path: edit_classroom_path(@classroom), icon: "fa-pencil", title: "Edit classroom", aria_label: "Edit classroom", text_class: "text-black" } } %>
             <% end %>
             <% if policy(Classroom).destroy? %>
               <%= render partial: "components/action_icon_button", locals: { options: { path: classroom_path(@classroom), icon: "fa-trash", title: "Delete classroom", aria_label: "Delete classroom", text_class: "text-red-600", method: :delete, data: { turbo_confirm: "Are you sure you want to delete this classroom? This action cannot be undone." } } } %>

--- a/app/views/components/_action_icon_button.html.erb
+++ b/app/views/components/_action_icon_button.html.erb
@@ -1,9 +1,9 @@
 <% if options[:method] %>
-  <%= button_to options[:path], method: options[:method], data: options[:data] || {}, class: "inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 #{options[:text_class] || 'text-blue-600'} hover:text-blue-800 hover:bg-blue-50 rounded-lg transition-all duration-150 group", title: options[:title], aria: { label: options[:aria_label] } do %>
+  <%= button_to options[:path], method: options[:method], data: options[:data] || {}, class: "inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 #{options[:text_class] || 'text-black'} hover:text-[var(--sitf-secondary-chart2)] hover:bg-blue-50 rounded-lg transition-all duration-150 group", title: options[:title], aria: { label: options[:aria_label] } do %>
     <i class="fa <%= options[:icon] %> fa-sm sm:fa-lg group-hover:scale-110 transition-transform duration-150"></i>
   <% end %>
 <% else %>
-  <%= link_to options[:path], class: "inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 #{options[:text_class] || 'text-blue-600'} hover:text-blue-800 hover:bg-blue-50 rounded-lg transition-all duration-150 group", title: options[:title], aria: { label: options[:aria_label] }, data: options[:data] || {} do %>
+  <%= link_to options[:path], class: "inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 #{options[:text_class] || 'text-black'} hover:text-[var(--sitf-secondary-chart2)] hover:bg-blue-50 rounded-lg transition-all duration-150 group", title: options[:title], aria: { label: options[:aria_label] }, data: options[:data] || {} do %>
     <i class="fa <%= options[:icon] %> fa-sm sm:fa-lg group-hover:scale-110 transition-transform duration-150"></i>
   <% end %>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,7 +16,7 @@
           <%= render_checkbox name: "user[remember_me]", label: "Remember Me" %>
         <% end %>
 
-        <%= render_button "Forgot your password?", href: new_password_path(resource_name), variant: :ghost, class: "text-sm font-semibold text-[#00698C] hover:text-blue-500", as: :link %>
+        <%= render_button "Forgot your password?", href: new_password_path(resource_name), variant: :ghost, class: "text-sm font-semibold text-black underline hover:text-[var(--sitf-secondary-chart2)]", as: :link %>
       </div>
 
         <%= render_button "Sign in", class: "flex w-full justify-center rounded-md bg-[#00698C] px-3 py-1.5 text-sm/6  text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600", type: "submit" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
 								<div class="text-gray-700 trix-content">
 									<%= @current_announcement.excerpt %>
 								</div>
-								<%= link_to "Read More", announcement_path(@current_announcement), class: "inline-flex items-center text-teal-600 hover:text-teal-700 font-medium text-xs mt-2" %>
+								<%= link_to "Read More", announcement_path(@current_announcement), class: "inline-flex items-center text-black underline hover:text-[var(--sitf-secondary-chart2)] font-medium text-xs mt-2" %>
 							</div>
 						<% end %>
 					<% else %>

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -37,12 +37,12 @@
           <% if stock.company_website.present? %>
             <div>
               <label class="text-sm font-medium text-gray-600">Website</label>
-              <p class="mt-1 text-blue-600 hover:text-blue-800">
+              <p class="mt-1">
                 <%= link_to(
                   stock.company_website,
                   safe_url(stock.company_website),
                   target: "_blank",
-                  class: "underline"
+                  class: "text-black underline hover:text-[var(--sitf-secondary-chart2)]"
                 ) %>
               </p>
             </div>


### PR DESCRIPTION
Resolves #706

## Changes

Standardized all link colors across the application for consistency:
- **Default state:** Black text with underline
- **Hover state:** Light teal color using `--sitf-secondary-chart2` CSS variable

## Implementation Details

- Updated inline Tailwind classes in 8 view files
- Modified `_action_icon_button` component default colors
- Used CSS variable `var(--sitf-secondary-chart2)` instead of hardcoded hex for maintainability

## Files Changed

- `app/views/home/index.html.erb` - Announcement "Read More" links
- `app/views/classrooms/index.html.erb` - Classroom name links
- `app/views/classrooms/show.html.erb` - Edit action icons
- `app/views/classrooms/_classroom_students_table.html.erb` - Student username links and edit icons
- `app/views/classrooms/_grade_books_list.html.erb` - Grade book links
- `app/views/components/_action_icon_button.html.erb` - Component default colors
- `app/views/stocks/_stock.html.erb` - Company website links
- `app/views/devise/sessions/new.html.erb` - "Forgot password" link

## Testing

- ✅ Manually tested all affected pages
- ✅ Verified hover effects work correctly
- ✅ Ran `bin/lint` - all checks passed
- ✅ Ran `bin/rails test` - all tests passed

## Approach

I went with **Option B** (updating inline Tailwind classes) to match the existing codebase pattern rather than creating a global CSS class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)