### PR TITLE
Update buy/sell button icons to Lucide arrows

### DIFF
--- a/app/views/stocks/_index_row.html.erb
+++ b/app/views/stocks/_index_row.html.erb
@@ -25,10 +25,16 @@
         <%= @portfolio&.shares_owned(stock.id) || 0 %>
       </span>
     </td>
-    <td class="table-body-cell table-body-cell-center" colspan="2">
+    <td class="table-body-cell table-body-cell-center whitespace-nowrap" colspan="2">
       <% if policy(stock).show_trading_link? %>
-        <%= link_to '<i class="fa-solid fa-angle-up"></i> Buy'.html_safe, new_order_path(stock_id: stock.id, transaction_type: :buy), class: "tw-btn-buy -ml-1", style: "margin-right: 100px;", data: { turbo_frame: "modal_frame" } %>
-        <%= link_to '<i class="fa-solid fa-angle-down"></i> Sell'.html_safe, new_order_path(stock_id: stock.id, transaction_type: :sell), class: "tw-btn-sell -mr-1", data: { turbo_frame: "modal_frame" } %>
+        <div class="flex gap-2 justify-center">
+          <%= link_to new_order_path(stock_id: stock.id, transaction_type: :buy), class: "tw-btn-buy", data: { turbo_frame: "modal_frame" } do %>
+            <%= lucide_icon("arrow-up") %> Buy
+          <% end %>
+          <%= link_to new_order_path(stock_id: stock.id, transaction_type: :sell), class: "tw-btn-sell", data: { turbo_frame: "modal_frame" } do %>
+            <%= lucide_icon("arrow-down") %> Sell
+          <% end %>
+        </div>
       <% end %>
     </td>
   <% end %>

--- a/app/views/stocks/_stocks_table.html.erb
+++ b/app/views/stocks/_stocks_table.html.erb
@@ -26,17 +26,21 @@
       <td class="px-4 py-2">
         <%= current_user.portfolio.shares_owned(stock.id) %>
       </td>
-        <td class="px-4 py-2">
+        <td class="px-4 py-2 whitespace-nowrap">
+          <div class="flex gap-2">
             <% if stock.archived? %>
               <span class="tw-btn-buy opacity-50 cursor-not-allowed">
-                <i class="fa-solid fa-angle-up"></i> Buy
+                <%= lucide_icon("arrow-up") %> Buy
               </span>
             <% else %>
-              <%= link_to '<i class="fa-solid fa-angle-up"></i> Buy'.html_safe, new_order_path(stock_id: stock.id, transaction_type: :buy), class: "tw-btn-buy", data: { turbo_frame: "modal_frame" } %>
+              <%= link_to new_order_path(stock_id: stock.id, transaction_type: :buy), class: "tw-btn-buy", data: { turbo_frame: "modal_frame" } do %>
+                <%= lucide_icon("arrow-up") %> Buy
+              <% end %>
             <% end %>
-        </td>
-        <td class="px-4 py-2">
-          <%= link_to '<i class="fa-solid fa-angle-down"></i> Sell'.html_safe, new_order_path(stock_id: stock.id, transaction_type: :sell), class: "tw-btn-sell", data: { turbo_frame: "modal_frame" } %>
+            <%= link_to new_order_path(stock_id: stock.id, transaction_type: :sell), class: "tw-btn-sell", data: { turbo_frame: "modal_frame" } do %>
+              <%= lucide_icon("arrow-down") %> Sell
+            <% end %>
+          </div>
         </td>
       <% end %>
     </tr>


### PR DESCRIPTION
Resolves #718

## Changes

### 1. Updated Button Icons
- Replaced Font Awesome icons (`fa-angle-up`/`fa-angle-down`) with Lucide icons (`arrow-up`/`arrow-down`)
- Modernizes icon library usage (SVG-based instead of font-based)

### 2. Fixed Button Layout (Bonus Fix)
While implementing the icon changes, I noticed the Buy/Sell buttons were wrapping onto separate lines on smaller screens. Fixed this by:
- Combining both buttons into a single table cell with flex layout
- Added `whitespace-nowrap` to parent cell to prevent wrapping
- Removed inline HTML strings in favor of cleaner ERB block syntax

## Files Changed
- `app/views/stocks/_stocks_table.html.erb`
- `app/views/stocks/_index_row.html.erb`

## Testing
- ✅ Tested in browser - icons display correctly
- ✅ Verified buttons don't wrap on narrow screens
- ✅ Ran `bin/lint` - all checks passed
- ✅ Ran `bin/rails test` - all tests passed

## Screenshots
Before:
<img width="212" height="82" alt="buttons_spans_two_line" src="https://github.com/user-attachments/assets/ae520ab2-d658-4c2a-b68d-e153bfa3bbd2" />

After:
<img width="1213" height="351" alt="after_PR" src="https://github.com/user-attachments/assets/a3837ca9-25fd-405c-867f-64a5c81fce0e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)