### PR TITLE
Add Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+Like the technical community as a whole, the Ruby for Good team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to when they're participating within this community and project. These rules apply equally to founders, mentors and those seeking help and guidance.
+
+This isn't an exhaustive list of things that you can't do. Rather, take it in the spirit in which it's intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+
+This code of conduct applies to all spaces managed by the Ruby for Good team or at Georgetown University. This includes IRC, Slack, the mailing lists, the issue tracker, Ruby for Good events, and any other forums created by the project team which the community uses for communication.
+
+Be welcoming, friendly, and patient. Be considerate. Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+
+Be respectful. Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Ruby for Good community should be respectful when dealing with other members as well as with people outside the Ruby for Good community.
+
+Be careful in the words that you choose. We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+
+- Violent threats or language directed against another person.
+- Sexist, racist, or otherwise discriminatory jokes and language.
+- Posting sexually explicit or violent material.
+- Posting (or threatening to post) other people's personally identifying information ("doxing").
+- Personal insults, especially those using racist or sexist terms.
+- Unwelcome sexual attention.
+- Advocating for, or encouraging, any of the above behavior.
+- Repeated harassment of others. In general, if someone asks you to stop, then stop.
+- If you believe someone is violating the code of conduct, we ask that you report it by emailing [Teresa Finn](mailto:teresa@rubyforgood.org) or [Kalimar Maia](mailto:kalimar@rubyforgood.org). Any email received will be kept confidential.
+
+When we disagree, try to understand why. Disagreements, both social and technical, happen all the time and Ruby is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we're different. The strength of Ruby comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn't mean that they're wrong. Don't forget that it is human to err and blaming each other doesn't get us anywhere, rather offer to help resolving issues and to help learn from mistakes.
+
+If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the event with no refund. The organizers and volunteers will be introduced at the beginning of the event.
+
+We're people trying to make the world better.
+
+_For our Code of Conduct, we have based ours on the excellent one made by the Django Project._


### PR DESCRIPTION
## Summary
- Adds `code-of-conduct.md` to establish community guidelines
- Based on Ruby for Good's standard Code of Conduct (same as human-essentials project)
- Defines expected behavior and reporting process

## Changes
- Created `code-of-conduct.md` in project root
- Content copied from Ruby for Good template used across their projects
- Includes contact emails for reporting violations

## Notes
This is a standard documentation file that establishes community expectations and provides a reporting mechanism for code of conduct violations. The content is consistent with other Ruby for Good projects.

Resolves #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)