### PR TITLE
Fix broken issue template by adding title placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -1,6 +1,6 @@
 name: Issue Template
 description: Report an issue or request a feature
-title: ""
+title: "Issue: "
 labels: ["needs-triage"]
 
 body:


### PR DESCRIPTION
## Summary
- Fixes broken issue template that wasn't being recognized by GitHub
- Changes `title: ""` to `title: "Issue: "` to provide non-empty placeholder
- Enables the template to properly display form fields and auto-apply labels

## Changes
- Updated `.github/ISSUE_TEMPLATE/issue_template.yml` line 3
- Changed empty title string to "Issue: " placeholder

## Testing
- Syntax follows [GitHub's official documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)
- Could not test functionally (requires merging to default branch)
- Maintainers can verify the template works after merge

## Expected Behavior After Fix
When users create a new issue:
1. Title will be pre-filled with "Issue: "
2. Form will show two required textarea fields
3. `needs-triage` label will auto-apply

Resolves #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)