### PR TITLE
Improve archive confirmation message and rename unarchive to activate

### DIFF
--- a/app/controllers/admin/classrooms_controller.rb
+++ b/app/controllers/admin/classrooms_controller.rb
@@ -48,7 +48,7 @@ module Admin
     def toggle_archive
       classroom = Classroom.find(params[:id])
       classroom.update!(archived: !classroom.archived)
-      flash[:notice] = classroom.archived? ? "Classroom has been archived." : "Classroom has been unarchived."
+      flash[:notice] = classroom.archived? ? "Classroom has been archived." : "Classroom has been activated."
       redirect_to admin_classrooms_path
     end
   end

--- a/app/views/admin/classrooms/_collection_item_actions.html.erb
+++ b/app/views/admin/classrooms/_collection_item_actions.html.erb
@@ -10,11 +10,11 @@
   <td>
     <% if resource.archived? %>
       <%= button_to(
-        "Unarchive",
+        "Activate",
         [:toggle_archive, namespace, resource],
         class: "link link--success",
         method: :patch,
-        data: { turbo_confirm: "Are you sure you want to unarchive this classroom?" }
+        data: { turbo_confirm: "Are you sure you want to activate this classroom?" }
       ) %>
     <% else %>
       <%= button_to(
@@ -22,7 +22,7 @@
         [:toggle_archive, namespace, resource],
         class: "link link--danger",
         method: :patch,
-        data: { turbo_confirm: "Are you sure you want to archive this classroom?" }
+        data: { turbo_confirm: "Are you sure you want to archive this classroom? Teachers and students will no longer be able to access it, but all historical data will be preserved." }
       ) %>
     <% end %>
   </td>

--- a/app/views/admin/classrooms/show.html.erb
+++ b/app/views/admin/classrooms/show.html.erb
@@ -34,11 +34,11 @@ as well as a link to its edit page.
 
     <% if page.resource.archived? %>
       <%= button_to(
-        "Unarchive",
+        "Activate",
         [:toggle_archive, namespace, page.resource],
         class: "button button--success",
         method: :patch,
-        data: { turbo_confirm: "Are you sure you want to unarchive this classroom?" }
+        data: { turbo_confirm: "Are you sure you want to activate this classroom?" }
       ) %>
     <% else %>
       <%= button_to(
@@ -46,7 +46,7 @@ as well as a link to its edit page.
         [:toggle_archive, namespace, page.resource],
         class: "button button--danger",
         method: :patch,
-        data: { turbo_confirm: "Are you sure you want to archive this classroom?" }
+        data: { turbo_confirm: "Are you sure you want to archive this classroom? Teachers and students will no longer be able to access it, but all historical data will be preserved." }
       ) %>
     <% end %>
   </div>

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -69,13 +69,13 @@ class ClassroomsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Classroom has been archived.", flash[:notice]
   end
 
-  test "unarchive classroom" do
+  test "activate classroom" do
     sign_in(@admin)
     @classroom.update!(archived: true)
     patch toggle_archive_admin_classroom_path(@classroom)
     assert_redirected_to admin_classrooms_path
     assert_not @classroom.reload.archived?
-    assert_equal "Classroom has been unarchived.", flash[:notice]
+    assert_equal "Classroom has been activated.", flash[:notice]
   end
 
   test "admins can see all classrooms in index" do


### PR DESCRIPTION
## Summary
- Improves archive confirmation message with clear context about consequences
- Renames "Unarchive" button to "Activate" for more intuitive terminology
- Updates flash messages and tests to match new terminology

## Changes

### Button Labels
- Changed "Unarchive" → "Activate" in both collection and show views
- Makes the action more intuitive and positive

### Confirmation Messages
**Archive confirmation (improved):**
> Are you sure you want to archive this classroom? Teachers and students will no longer be able to access it, but all historical data will be preserved.

**Activate confirmation (updated for consistency):**
> Are you sure you want to activate this classroom?

### Flash Messages
- Changed success message from "Classroom has been unarchived." to "Classroom has been activated."
- Updated test assertions to match

## Files Modified
- `app/views/admin/classrooms/_collection_item_actions.html.erb` - Archive/Activate buttons in list view
- `app/views/admin/classrooms/show.html.erb` - Archive/Activate buttons in detail view
- `app/controllers/admin/classrooms_controller.rb` - Flash message
- `test/controllers/classrooms_controller_test.rb` - Test assertions and test name

## Test Plan
- [x] Run `bin/lint` - passes
- [x] Run `bin/rails test` - passes
- [x] Verified all user-facing text is consistent with new terminology

## Screenshots
![output](https://github.com/user-attachments/assets/8acee494-f2ce-4309-8f54-7e07e106bcb1)

## Notes
I also updated the flash message and test even though it wasn't explicitly mentioned in the issue, to ensure consistency across all user-facing text.

Resolves #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)