### PR TITLE
Fix student portfolio money input to recognize dollars not cents

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -175,7 +175,8 @@ module Admin
     end
 
     def fund_amount
-      @fund_amount ||= transaction_params[:add_fund_amount]
+      amount = transaction_params[:add_fund_amount]
+      @fund_amount ||= amount.present? ? (amount.to_f * 100).to_i : nil
     end
 
     def transaction_type

--- a/test/controllers/admin/students_controller_test.rb
+++ b/test/controllers/admin/students_controller_test.rb
@@ -36,7 +36,7 @@ module Admin
     test "given a add_fund_amount, creates a transaction" do
       params = { student: {
         transaction_type: "deposit",
-        add_fund_amount: 1_050,
+        add_fund_amount: 10.50,
         transaction_reason: :awards
       } }
       admin = create(:admin)
@@ -148,7 +148,7 @@ module Admin
     test "add_transaction stores transaction_description" do
       params = { student: {
         transaction_type: "deposit",
-        add_fund_amount: 1_050,
+        add_fund_amount: 10.50,
         transaction_reason: :awards,
         transaction_description: "Extra credit for science fair"
       } }
@@ -169,7 +169,7 @@ module Admin
     test "add_transaction creates debit transaction" do
       params = { student: {
         transaction_type: "debit",
-        add_fund_amount: 500,
+        add_fund_amount: 5.00,
         transaction_reason: :administrative_adjustments
       } }
       admin = create(:admin)


### PR DESCRIPTION
## Summary
- Fixes bug where adding money to student portfolio treated dollar input as cents
- Users can now enter amounts in dollars (e.g., `15` for $15.00, `15.50` for $15.50)
- Converts dollar input to cents before storing in database

## Problem
On the Admin Student Edit page, when adding/removing money from a student portfolio, the form expected dollar amounts but was storing them as cents:
- Entering `15` stored as 15 cents ($0.15) instead of $15.00
- Entering `15.00` stored as 15 cents ($0.15) instead of $15.00
- Entering `15.50` worked by accident (stored as 15.5 cents)

## Solution
Modified `fund_amount` method in `students_controller.rb` to:
1. Convert dollar input to cents by multiplying by 100
2. Handle nil/blank amounts correctly to preserve validation

## Changes
- `app/controllers/admin/students_controller.rb`: Updated `fund_amount` to convert dollars to cents
- `test/controllers/admin/students_controller_test.rb`: Updated test fixtures to use dollar amounts

## Test Plan
- [x] Updated existing tests to reflect dollar input
- [x] Verified nil/blank amount validation still works
- [x] Run `bin/lint` - passes
- [x] Run `bin/rails test` - passes

## Testing Examples
After fix:
- Input: `15` → Stores: 1500 cents → Displays: $15.00 ✅
- Input: `15.50` → Stores: 1550 cents → Displays: $15.50 ✅
- Input: `15.00` → Stores: 1500 cents → Displays: $15.00 ✅

Resolves #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)