### PR TITLE
Fix new student button on Admin page

### DIFF
--- a/app/dashboards/student_dashboard.rb
+++ b/app/dashboards/student_dashboard.rb
@@ -13,6 +13,7 @@ class StudentDashboard < Administrate::BaseDashboard
     id: Field::Number,
     classroom: Field::BelongsTo,
     email: Field::String,
+    password: Field::Password,
     portfolio: Field::HasOne,
     portfolio_path: PortfolioLink,
     username: Field::String,
@@ -48,6 +49,7 @@ class StudentDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     username
+    password
     classroom
     email
     portfolio

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -61,6 +61,7 @@ and renders all form fields for a resource's editable attributes.
     <%= f.submit %>
   </div>
 <% end %>
+<% if page.resource.persisted? %>
 <hr />
 <%= form_with url: admin_student_add_transaction_path(page.resource), method: :post do |form| %>
   <% if action_name == 'edit' || action_name == 'update' %>
@@ -106,4 +107,5 @@ and renders all form fields for a resource's editable attributes.
   </div>
 
   <%= form.submit "Add transaction", class: "button" %>
+<% end %>
 <% end %>


### PR DESCRIPTION
## Summary
- Fixed "New student" button failing on Admin page
- Added password field to student creation form (required by Devise)
- Prevented transaction form from rendering on new student page

## Changes
- Added `password: Field::Password` to Student dashboard ATTRIBUTE_TYPES
- Added `password` to Student dashboard FORM_ATTRIBUTES
- Wrapped transaction form section in `<% if page.resource.persisted? %>` check

## Root Cause
1. Transaction form was trying to render on new student page
2. `admin_student_add_transaction_path(page.resource)` failed because `page.resource` is nil for new students
3. Password field was missing from form (Devise requires it)

## Test Plan
- [x] Navigate to /admin/students/new
- [x] Fill in username, password, select classroom
- [x] Submit form - student created successfully
- [x] Edit existing student - transaction form appears
- [x] Verify transaction form works on edit page

## Screenshot
![output](https://github.com/user-attachments/assets/0514b24e-0c5b-4332-a8d4-30f81971d604)

Resolves #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)