### PR TITLE
Fix Invest Now button to go to trading floor

### DIFF
--- a/app/views/portfolios/_earnings_to_invest_card.html.erb
+++ b/app/views/portfolios/_earnings_to_invest_card.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-col justify-center">
       <p class="text-sm text-gray-600">My Earnings to Invest</p>
       <p class="text-2xl font-semibold leading-tight tracking-tight mt-1"><%= number_to_currency(@portfolio.cash_balance) %></p>
-      <%= link_to "Invest Now", orders_path, class: "mt-2 bg-[var(--sitf-secondary-teal)] hover:bg-[var(--sitf-4)] text-white font-medium px-6 py-2.5 rounded-full shadow-sm w-fit transition-colors" %>
+      <%= link_to "Invest Now", stocks_path, class: "mt-2 bg-[var(--sitf-secondary-teal)] hover:bg-[var(--sitf-4)] text-white font-medium px-6 py-2.5 rounded-full shadow-sm w-fit transition-colors" %>
     </div>
     <%= image_tag 'investment-funds.png', class: 'h-40 w-auto object-contain select-none pointer-events-none self-end mb-6 -mr-8', alt: 'Investment Funds' %>
   </div>


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the "Invest Now" button on the portfolio page to navigate to the trading floor instead of the transactions page.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/794

## Changes
- Changed link target from `orders_path` to `stocks_path` in `_earnings_to_invest_card.html.erb`

## Screenshots (if applicable)
![output](https://github.com/user-attachments/assets/245e5f19-2197-48f7-a183-6fc665c92c71)

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
Simple one-line fix changing button destination from transactions page to trading floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)