### PR TITLE
Show total stocks value as an integer

### DIFF
--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -27,7 +27,7 @@
         <%# Total Stocks %>
         <div class="bg-white rounded-[22px] border border-black/30 py-4 px-5 flex flex-col justify-between min-h-[120px]">
           <div class="text-sm text-gray-600">Total Stocks</div>
-          <div class="text-2xl font-semibold"><%= @portfolio.portfolio_stocks.sum(:shares) %></div>
+          <div class="text-2xl font-semibold"><%= @portfolio.portfolio_stocks.sum(:shares).to_i %></div>
           <div><%# Trending up/down this month will go here %></div>
         </div>
       </div>


### PR DESCRIPTION
# Pull Request

## Summary
Currently orders can only be placed for whole shares of stock (no fractional shares). So the `Total Stocks` section in `My PortFolio` should show integer values instead of decimal.


## Related Issue
Resolves 
https://github.com/rubyforgood/stocks-in-the-future/issues/808

## Changes
- Converted total shares value from decimal to integer.

## Screenshots (if applicable)
`NA`

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
