### PR TITLE
replace 'destroy?' with 'toggle_archive?' on ClassroomPolicy / add au…

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,6 +8,8 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
+    include Pundit::Authorization
+
     before_action :authenticate_admin
 
     def authenticate_admin

--- a/app/controllers/admin/classrooms_controller.rb
+++ b/app/controllers/admin/classrooms_controller.rb
@@ -47,6 +47,7 @@ module Admin
 
     def toggle_archive
       classroom = Classroom.find(params[:id])
+      authorize classroom, :toggle_archive?
       classroom.update!(archived: !classroom.archived)
       flash[:notice] = classroom.archived? ? "Classroom has been archived." : "Classroom has been activated."
       redirect_to admin_classrooms_path

--- a/app/policies/classroom_policy.rb
+++ b/app/policies/classroom_policy.rb
@@ -25,7 +25,7 @@ class ClassroomPolicy < ApplicationPolicy
     user.admin?
   end
 
-  def destroy?
+  def toggle_archive?
     user.admin?
   end
 

--- a/test/controllers/admin/classrooms_controller_test.rb
+++ b/test/controllers/admin/classrooms_controller_test.rb
@@ -88,5 +88,15 @@ module Admin
       assert_response :redirect
       assert_redirected_to root_url
     end
+
+    test "non-admin users cannot toggle archive classrooms" do
+      sign_out @admin
+      teacher = create(:teacher)
+      sign_in teacher
+
+      patch toggle_archive_admin_classroom_url(@classroom)
+      assert_response :redirect
+      assert_redirected_to root_url
+    end
   end
 end

--- a/test/policies/classroom_policy_test.rb
+++ b/test/policies/classroom_policy_test.rb
@@ -17,7 +17,7 @@ class ClassroomPolicyTest < ActiveSupport::TestCase
     assert_permit admin, classroom, :create
     assert_permit admin, classroom, :edit
     assert_permit admin, classroom, :update
-    assert_permit admin, classroom, :destroy
+    assert_permit admin, classroom, :toggle_archive
   end
 
   test "classroom policy allows teacher only `index` and `show` classroom routes" do
@@ -30,7 +30,7 @@ class ClassroomPolicyTest < ActiveSupport::TestCase
     refute_permit teacher, classroom, :create
     refute_permit teacher, classroom, :edit
     refute_permit teacher, classroom, :update
-    refute_permit teacher, classroom, :destroy
+    refute_permit teacher, classroom, :toggle_archive
   end
 
   test "classroom policy does not allow student any classroom routes" do
@@ -43,7 +43,7 @@ class ClassroomPolicyTest < ActiveSupport::TestCase
     refute_permit student, classroom, :create
     refute_permit student, classroom, :edit
     refute_permit student, classroom, :update
-    refute_permit student, classroom, :destroy
+    refute_permit student, classroom, :toggle_archive
   end
 
   test "classroom policy allows admins access to all the classrooms" do


### PR DESCRIPTION
…thorize check for toggle_archive / adjust/add specs (#779)

# Pull Request

## Summary
replace 'destroy?' with 'toggle_archive?' on ClassroomPolicy / add authorize check for toggle_archive / adjust/add specs (#779)

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/779#issuecomment-3448191096

## Changes
- replace `destroy?` with `toggle_archive?` on `ClassroomPolicy`
- add authorize check for new `toggle_archive?` method

## Screenshots (if applicable)

## Checklist
- [X] Issue is assigned (commenting on the issue page is needed)
- [X] Issue link added to the PR's description
- [X] Branch created from main
- [X] Commits are small and descriptive
- [X] Ran linter and fixed issues
- [X] Ran tests and all tests pass
- [X] CI checks passing
- [X] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
