### PR TITLE
Fix portfolio seed data to use transactions instead of current_position

### DIFF
--- a/db/seeds/partials/portfolio_transactions.rb
+++ b/db/seeds/partials/portfolio_transactions.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# Create transactions for Student user
+student = User.find_by(email: "student@example.com")
+
+if student
+  portfolio = Portfolio.find_or_create_by(user: student)
+
+  # Initial deposit to give student starting balance
+  PortfolioTransaction.create(
+    portfolio: portfolio,
+    transaction_type: :deposit,
+    amount_cents: 10_000_00
+  )
+
+  puts "Seeded portfolio transactions for Student user"
+  Rails.logger.info "Seeded portfolio transactions for Student user"
+else
+  puts "Student user not found. Skipping Student portfolio transactions seeding."
+  Rails.logger.warn "Student user not found. Skipping Student portfolio transactions seeding."
+end
+
+# Create transactions for Mike user
 mike = User.find_by(email: "mike@example.com")
 
 if mike

--- a/db/seeds/partials/users.rb
+++ b/db/seeds/partials/users.rb
@@ -26,8 +26,7 @@ unless student.persisted?
     password_confirmation: "password",
     admin: false,
     type: "Student",
-    classroom: Classroom.first,
-    portfolio_attributes: { current_position: 10_000.0 }
+    classroom: Classroom.first
   }
   student.save
   puts "Created Student user: #{student.email}"
@@ -64,8 +63,7 @@ unless mike.persisted?
     password_confirmation: "password",
     admin: false,
     type: "Student",
-    classroom: Classroom.first,
-    portfolio_attributes: { current_position: 10_000.0 }
+    classroom: Classroom.first
   }
   mike.save
   puts "Created portfolio transactions user: #{mike.email}"


### PR DESCRIPTION
## Summary
- Fixed portfolio seed data to use proper transactions instead of directly setting current_position
- Portfolio balances are now calculated from transactions (deposits, earnings, orders)
- Makes seed data realistic and matches how production portfolios work

## Changes
- Removed `current_position: 10_000.0` from Student and Mike user creation in `db/seeds/partials/users.rb`
- Added `PortfolioTransaction` deposit for Student user in `db/seeds/partials/portfolio_transactions.rb`
- Portfolio balances now correctly calculated from transaction history

## Root Cause
Previously, portfolios were created with `current_position: 10_000.0` directly set, which:
- Showed $10,000 balance without any transaction history
- Didn't reflect how real portfolios work (transactions create balance)
- Was confusing for developers learning the system

## Test Plan
- [x] Run `bin/dc rails db:reset` to test seed data
- [x] Verify Student user has transactions and calculated balance
- [x] Verify Mike user has transactions and calculated balance
- [x] Confirm portfolios work correctly in development

## Testing Results
```
Student cash: $9,932.03 (from 1 deposit transaction + pending orders)
Mike cash: $24,712.04 (from 10 transactions including deposits, withdrawals, and orders)
```

Resolves #793