### PR TITLE
Persist teacher name after creating a teacher from admin

### DIFF
--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -63,7 +63,7 @@ module Admin
     private
 
     def teacher_params
-      params.expect(teacher: %i[email username classroom_id])
+      params.expect(teacher: %i[email name username classroom_id])
     end
 
     # See https://administrate-demo.herokuapp.com/customizing_controller_actions

--- a/test/controllers/admin/teachers_controller_test.rb
+++ b/test/controllers/admin/teachers_controller_test.rb
@@ -54,5 +54,31 @@ module Admin
 
       assert_redirected_to admin_teacher_path(teacher)
     end
+
+    test "create" do
+      admin = create(:admin)
+      classroom = create(:classroom)
+      sign_in(admin)
+
+      teacher_params = {
+        email: "newteacher@example.com",
+        name: "New Teacher",
+        username: "newteacher1",
+        classroom_id: classroom.id
+      }
+
+      assert_difference("Teacher.count") do
+        post admin_teachers_path, params: { teacher: teacher_params }
+      end
+
+      teacher = Teacher.order(created_at: :desc).first
+      assert_equal "newteacher@example.com", teacher.email
+      assert_equal "New Teacher", teacher.name
+      assert_equal "newteacher1", teacher.username
+      assert_includes teacher.classrooms, classroom
+
+      assert_redirected_to admin_teachers_path
+      assert_match I18n.t("teachers.create.notice"), flash[:notice]
+    end
   end
 end


### PR DESCRIPTION
# Pull Request

## Summary
Teacher name was not persisting after creating a teacher from admin. This was happening because `name` was not added in `teacher_params`. In this PR `name` is added to `teacher_params`. Also tests have been added for teachers `create` action

## Related Issue
Resolves #809

## Changes
- Added name in `teacher_params`

## Screenshots (if applicable)
`NA`

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
