### PR TITLE
Fixed currency formatting for Total Cash Value

### DIFF
--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -21,7 +21,7 @@
         <%# Total Cash Value %>
         <div class="bg-white rounded-[22px] border border-black/30 py-4 px-5 flex flex-col justify-between min-h-[120px]">
           <div class="text-sm text-gray-600">Total Cash Value</div>
-          <div class="text-2xl font-semibold">$<%= sprintf('%.2f', @portfolio.cash_balance) %></div>
+          <div class="text-2xl font-semibold"><%= number_to_currency(@portfolio.cash_balance) %></div>
           <div><%# Trending up/down this month will go here %></div>
         </div>
         <%# Total Stocks %>


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves a currency formatting inconsistency on the portfolio page. It updates the "Total Cash Value" card to use the `number_to_currency` Rails helper.

## Related Issue
Resolves 
https://github.com/rubyforgood/stocks-in-the-future/issues/828

## Changes
- Replaced the manual `$<%= sprintf('%.2f', ...)` formatting for the "Total Cash Value" with the `number_to_currency` helper.

## Screenshots 

Before
<img width="518" height="144" alt="image" src="https://github.com/user-attachments/assets/493b7a9b-e342-4b6c-9841-9eb1ec94e043" />

After
<img width="478" height="150" alt="Screenshot from 2025-11-06 23-26-45" src="https://github.com/user-attachments/assets/e356cd2c-8386-4268-9282-caf95b0c90fb" />


## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members