### PR TITLE
Fix alignment between Trading Floor header and stocks table

### DIFF
--- a/app/views/stocks/index.html.erb
+++ b/app/views/stocks/index.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full ps-4">
+<div class="w-full px-6">
   <% if notice.present? %>
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
   <% end %>
@@ -12,7 +12,7 @@
     <% end %>
   </div>
 
-  <main class="flex-1 p-6">
+  <main class="flex-1 py-6">
     <%= render "stocks/stocks_table", title: "Active Stocks", stocks: @stocks.active %>
     <%= render "stocks/stocks_table", title: "Archived Stocks", stocks: @stocks.archived %>
   </main>


### PR DESCRIPTION
## Summary
Fixes visual misalignment between Trading Floor header and stock table content.

## Changes
- Changed wrapper from `ps-4` to `px-6` for consistent horizontal padding
- Changed main from `p-6` to `py-6` to remove duplicate horizontal padding
- Now header and main content both have 1.5rem left padding

## Result
- ✅ Trading Floor title aligns with Active Stocks section
- ✅ My Earnings to Invest card aligns with content below
- ✅ Consistent left padding throughout the page

## Testing
Manually verified at `/stocks` page - header and table content now align perfectly.

Resolves #852