### PR TITLE
Add test coverage for GradeBookPolicy

### DIFF
--- a/test/policies/grade_book_policy_test.rb
+++ b/test/policies/grade_book_policy_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GradeBookPolicyTest < ActiveSupport::TestCase
+  def setup
+    @admin = create(:admin)
+    @owner_teacher = create(:teacher)
+    @other_teacher = create(:teacher)
+    @student = create(:student)
+
+    @classroom = create(:classroom)
+    @classroom.teachers << @owner_teacher
+
+    @grade_book = create(:grade_book, classroom: @classroom)
+  end
+
+  test "show? allows admin and owner teacher, denies others" do
+    assert_permit @admin, @grade_book, :show
+    assert_permit @owner_teacher, @grade_book, :show
+    refute_permit @other_teacher, @grade_book, :show
+    refute_permit @student, @grade_book, :show
+  end
+
+  test "update? allows admin and owner teacher, denies others" do
+    assert_permit @admin, @grade_book, :update
+    assert_permit @owner_teacher, @grade_book, :update
+    refute_permit @other_teacher, @grade_book, :update
+    refute_permit @student, @grade_book, :update
+  end
+
+  test "finalize? allows only admin, denies everyone else" do
+    assert_permit @admin, @grade_book, :finalize
+    refute_permit @owner_teacher, @grade_book, :finalize
+    refute_permit @other_teacher, @grade_book, :finalize
+    refute_permit @student, @grade_book, :finalize
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds test coverage for the `GradeBookPolicy`.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/861

## Changes
- Created `test/policies/grade_book_policy_test.rb` 
- Added tests for `show?`.
- Added tests for `update?`.
- Added tests for `finalize?`.

## Checklist
- [X] Issue is assigned (commenting on the issue page is needed)
- [X] Issue link added to the PR's description
- [X] Branch created from main
- [X] Commits are small and descriptive
- [X] Ran linter and fixed issues
- [X] Ran tests and all tests pass
- [ ] CI checks passing
- [ ] Review requested from team members