### PR TITLE
E2E: Student Portfolio View Tests

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -5,6 +5,7 @@ class PortfoliosController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    authorize @portfolio
     @stocks = @portfolio.stocks
   end
 

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -24,20 +24,20 @@
           <div><%# Trending up/down this month will go here %></div>
         </div>
         <%# Total Cash Value %>
-        <div class="bg-white rounded-[22px] border border-black/30 py-4 px-5 flex flex-col justify-between min-h-[120px]">
+        <div class="bg-white rounded-[22px] border border-black/30 py-4 px-5 flex flex-col justify-between min-h-[120px]" data-testid="cash-balance">
           <div class="text-sm text-gray-600">Total Cash Value</div>
           <div class="text-2xl font-semibold"><%= number_to_currency(@portfolio.cash_balance) %></div>
           <div><%# Trending up/down this month will go here %></div>
         </div>
         <%# Total Stocks %>
-        <div class="bg-white rounded-[22px] border border-black/30 py-4 px-5 flex flex-col justify-between min-h-[120px]">
+        <div class="bg-white rounded-[22px] border border-black/30 py-4 px-5 flex flex-col justify-between min-h-[120px]" data-testid="total-stocks">
           <div class="text-sm text-gray-600">Total Stocks</div>
           <div class="text-2xl font-semibold"><%= @portfolio.portfolio_stocks.sum(:shares).to_i %></div>
           <div><%# Trending up/down this month will go here %></div>
         </div>
       </div>
       <!-- Holdings Table -->
-      <div class="rounded-xl border border-black/60 bg-white overflow-hidden">
+      <div class="rounded-xl border border-black/60 bg-white overflow-hidden" data-testid="holdings-table">
         <div class="overflow-x-auto">
           <table class="w-full min-w-[700px] border-collapse">
           <colgroup class="hidden lg:table-column-group">

--- a/test/system/student_portfolio_view_test.rb
+++ b/test/system/student_portfolio_view_test.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class StudentPortfolioViewTest < ApplicationSystemTestCase
+  test "student views portfolio with cash and stock holdings" do
+    classroom = create(:classroom)
+    student = create(:student, :with_portfolio, classroom: classroom)
+    student.reload
+    portfolio = student.portfolio
+
+    # Give student some cash
+    create(:portfolio_transaction, :deposit, portfolio: portfolio, amount_cents: 100_000)
+
+    # Give student some stocks
+    stock_aapl = create(:stock, ticker: "AAPL", company_name: "Apple Inc.", price_cents: 15_000)
+    stock_googl = create(:stock, ticker: "GOOGL", company_name: "Google LLC", price_cents: 20_000)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock_aapl, shares: 5)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock_googl, shares: 3)
+
+    sign_in(student)
+    visit portfolio_path(portfolio)
+
+    # Verify page heading
+    assert_text "PORTFOLIO"
+    assert_text student.username.upcase
+
+    # Verify cash balance is displayed
+    within "[data-testid='cash-balance']" do
+      assert_text "$1,000.00"
+    end
+
+    # Verify stock holdings are displayed
+    within "[data-testid='holdings-table']" do
+      # AAPL holdings
+      assert_text "AAPL"
+      assert_text "5"
+      assert_text "$150.00"
+
+      # GOOGL holdings
+      assert_text "GOOGL"
+      assert_text "3"
+      assert_text "$200.00"
+    end
+
+    # Verify total stocks count
+    within "[data-testid='total-stocks']" do
+      assert_text "8"
+    end
+
+    sign_out(student)
+  end
+
+  test "student views portfolio with only cash (no stocks)" do
+    classroom = create(:classroom)
+    student = create(:student, :with_portfolio, classroom: classroom)
+    student.reload
+    portfolio = student.portfolio
+
+    # Give student cash but no stocks
+    create(:portfolio_transaction, :deposit, portfolio: portfolio, amount_cents: 50_000)
+
+    sign_in(student)
+    visit portfolio_path(portfolio)
+
+    # Verify page heading
+    assert_text "PORTFOLIO"
+
+    # Verify cash balance is displayed
+    within "[data-testid='cash-balance']" do
+      assert_text "$500.00"
+    end
+
+    # Verify no stock holdings
+    # The view may show an empty table but no "Trade" buttons
+    within "[data-testid='holdings-table']" do
+      # Table should be empty (no holdings rows with Trade buttons)
+      assert_no_text "Trade"
+    end
+
+    # Total stocks should be 0
+    within "[data-testid='total-stocks']" do
+      assert_text "0"
+    end
+
+    sign_out(student)
+  end
+
+  test "student views portfolio with no cash (only stocks)" do
+    classroom = create(:classroom)
+    student = create(:student, :with_portfolio, classroom: classroom)
+    student.reload
+    portfolio = student.portfolio
+
+    # Give student stocks but no cash (portfolio starts with $0)
+    stock_tsla = create(:stock, ticker: "TSLA", company_name: "Tesla Inc.", price_cents: 25_000)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock_tsla, shares: 4)
+
+    sign_in(student)
+    visit portfolio_path(portfolio)
+
+    # Verify page heading
+    assert_text "PORTFOLIO"
+
+    # Verify cash balance is $0
+    within "[data-testid='cash-balance']" do
+      assert_text "$0.00"
+    end
+
+    # Verify stock holdings are displayed
+    within "[data-testid='holdings-table']" do
+      assert_text "TSLA"
+      assert_text "4"
+      assert_text "$250.00"
+    end
+
+    # Verify total stocks count
+    within "[data-testid='total-stocks']" do
+      assert_text "4"
+    end
+
+    sign_out(student)
+  end
+
+  test "student views transaction history" do
+    classroom = create(:classroom)
+    student = create(:student, :with_portfolio, classroom: classroom)
+    student.reload
+    portfolio = student.portfolio
+
+    # Create various transaction types
+    create(:portfolio_transaction, :deposit, portfolio: portfolio, amount_cents: 10_000, reason: "Initial funding")
+    create(:portfolio_transaction, :credit, portfolio: portfolio, amount_cents: 5_000, reason: "Stock sale")
+    create(:portfolio_transaction, :debit, portfolio: portfolio, amount_cents: 3_000, reason: "Stock purchase")
+
+    sign_in(student)
+    visit portfolio_path(portfolio)
+
+    # NOTE: The current portfolio view doesn't display transaction history
+    # This test will verify IF transaction history section exists
+    # If not, this test documents the missing feature
+
+    # Try to find transaction history section
+    if has_css?("[data-testid='transaction-history']", wait: 1)
+      within "[data-testid='transaction-history']" do
+        assert_text "Initial funding"
+        assert_text "Stock sale"
+        assert_text "Stock purchase"
+        assert_text "$100.00"
+        assert_text "$50.00"
+        assert_text "$30.00"
+      end
+    else
+      # Document that transaction history is not currently displayed
+      skip "Transaction history not yet implemented in portfolio view"
+    end
+
+    sign_out(student)
+  end
+
+  test "student views empty portfolio (new account)" do
+    classroom = create(:classroom)
+    student = create(:student, :with_portfolio, classroom: classroom)
+    student.reload
+    portfolio = student.portfolio
+
+    # Portfolio was just created with no transactions or stocks
+    sign_in(student)
+    visit portfolio_path(portfolio)
+
+    # Verify page heading
+    assert_text "PORTFOLIO"
+
+    # Verify cash balance is $0
+    within "[data-testid='cash-balance']" do
+      assert_text "$0.00"
+    end
+
+    # Verify no stock holdings
+    within "[data-testid='holdings-table']" do
+      assert_no_text "Trade"
+    end
+
+    # Total stocks should be 0
+    within "[data-testid='total-stocks']" do
+      assert_text "0"
+    end
+
+    sign_out(student)
+  end
+
+  test "portfolio reflects real-time stock prices" do
+    classroom = create(:classroom)
+    student = create(:student, :with_portfolio, classroom: classroom)
+    student.reload
+    portfolio = student.portfolio
+
+    # Create stock with initial price
+    stock = create(:stock, ticker: "NFLX", company_name: "Netflix", price_cents: 30_000)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 2)
+
+    sign_in(student)
+    visit portfolio_path(portfolio)
+
+    # Verify initial price is displayed
+    within "[data-testid='holdings-table']" do
+      assert_text "$300.00" # Last Price column
+    end
+
+    # Update stock price in database (simulating price update)
+    stock.update!(price_cents: 35_000)
+
+    # Refresh page to see updated price
+    visit portfolio_path(portfolio)
+
+    # Verify updated price is displayed
+    within "[data-testid='holdings-table']" do
+      assert_text "$350.00" # Updated Last Price
+    end
+
+    sign_out(student)
+  end
+
+  test "student cannot view another student's portfolio" do
+    classroom = create(:classroom)
+    student_a = create(:student, :with_portfolio, classroom: classroom)
+    student_b = create(:student, :with_portfolio, classroom: classroom)
+    student_a.reload
+    student_b.reload
+    portfolio_b = student_b.portfolio
+
+    # Give student B some cash and stocks
+    create(:portfolio_transaction, :deposit, portfolio: portfolio_b, amount_cents: 20_000)
+    stock = create(:stock, ticker: "AMZN", company_name: "Amazon", price_cents: 40_000)
+    create(:portfolio_stock, portfolio: portfolio_b, stock: stock, shares: 1)
+
+    # Student A attempts to access Student B's portfolio
+    sign_in(student_a)
+
+    # Attempt to visit Student B's portfolio URL directly
+    visit portfolio_path(portfolio_b)
+
+    # Should be denied access (Pundit policy blocks) and redirected to own portfolio
+    # Verify Student A is viewing their own portfolio (not Student B's)
+    assert_text student_a.username.upcase
+
+    # Verify this is NOT Student B's portfolio by checking stock count
+    # Student B has 1 share of AMZN, Student A has 0
+    within "[data-testid='total-stocks']" do
+      assert_text "0"
+    end
+
+    # Verify Student B's stock is NOT shown
+    within "[data-testid='holdings-table']" do
+      assert_no_text "AMZN"
+    end
+
+    sign_out(student_a)
+  end
+end


### PR DESCRIPTION
## Summary
- Implements E2E system tests for student portfolio view workflow
- Covers 7 test scenarios including portfolio states and authorization
- Fixes security bug discovered during testing (missing authorization)
- Adds data-testid attributes for reliable test assertions

## Changes

### Tests Created (`test/system/student_portfolio_view_test.rb`)
1. ✅ Student views portfolio with cash and stock holdings
2. ✅ Student views portfolio with only cash (no stocks)
3. ✅ Student views portfolio with no cash (only stocks)
4. ⏭️ Student views transaction history (skipped - feature not implemented)
5. ✅ Student views empty portfolio (new account)
6. ✅ Portfolio reflects real-time stock prices
7. ✅ Student cannot view another student's portfolio (authorization)

### Security Fix
- Added `authorize @portfolio` to `PortfoliosController#show`
- Students can now ONLY view their own portfolios (enforces `PortfolioPolicy`)
- Before this fix, students could view any portfolio by changing the URL

### View Updates
- Added `data-testid` attributes to portfolio view elements:
  - `data-testid="cash-balance"` - Total Cash Value card
  - `data-testid="total-stocks"` - Total Stocks card
  - `data-testid="holdings-table"` - Holdings table

## Test Results
```bash
39 runs, 160 assertions, 0 failures, 0 errors, 1 skips
```
- 1 skip: Transaction history test (feature not yet implemented)
- All 6 other portfolio tests pass ✅

## Notes
- Transaction history test currently skips because the portfolio view doesn't display transaction history yet
- The test documents the expected behavior for when this feature is added
- Authorization fix is a security improvement - students previously could access other students' portfolios

## Testing Checklist
- [x] All new tests pass locally
- [x] RuboCop passes
- [x] Added data-testid attributes follow existing patterns
- [x] Authorization properly restricts access
- [x] Tests cover happy paths and edge cases

Resolves #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)