### PR TITLE
Add data-testid attributes to order/stock action buttons

### DIFF
--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -116,11 +116,11 @@
               <td class="table-body-cell table-body-cell-center">
                 <div class="flex justify-center space-x-2">
                   <% if order.pending? %>
-                    <%= link_to edit_order_path(order), class: "table-action-link" do %>
+                    <%= link_to edit_order_path(order), class: "table-action-link", data: { testid: "edit-order-button" } do %>
                       <i class="fa fa-pencil fa-lg"></i>
                     <% end %>
                     <%= form_with url: cancel_order_path(order), method: :patch, data: { confirm: t("orders.cancel.confirm"), turbo_confirm: t("orders.cancel.confirm") } do %>
-                      <button type="submit" class="table-action-button" title="Cancel">
+                      <button type="submit" class="table-action-button" title="Cancel" data-testid="cancel-order-button">
                         <i class="fa fa-ban fa-lg"></i>
                       </button>
                     <% end %>

--- a/app/views/stocks/_index_row.html.erb
+++ b/app/views/stocks/_index_row.html.erb
@@ -30,13 +30,13 @@
         <div class="flex gap-2 justify-center">
           <%= link_to new_order_path(stock_id: stock.id, transaction_type: :buy),
             class: "tw-btn-buy -ml-1",
-            data: { turbo_frame: "modal_frame" } do %>
+            data: { turbo_frame: "modal_frame", testid: "buy-stock-button" } do %>
               <%= lucide_icon("arrow-up") %> Buy
           <% end if !stock.archived? %>
 
           <%= link_to new_order_path(stock_id: stock.id, transaction_type: :sell),
             class: "tw-btn-sell -mr-1",
-            data: { turbo_frame: "modal_frame" } do %>
+            data: { turbo_frame: "modal_frame", testid: "sell-stock-button" } do %>
               <%= lucide_icon("arrow-down") %> Sell
           <% end %>
         </div>

--- a/test/system/student_trading_flow_test.rb
+++ b/test/system/student_trading_flow_test.rb
@@ -106,7 +106,7 @@ class StudentTradingFlowTest < ApplicationSystemTestCase
     visit orders_path
 
     within "tr", text: stock.ticker do
-      find("i.fa-pencil").click
+      find("[data-testid='edit-order-button']").click
     end
 
     fill_in "Number of shares", with: updated_shares
@@ -143,7 +143,7 @@ class StudentTradingFlowTest < ApplicationSystemTestCase
     assert_difference -> { Order.pending.count } => -1, -> { Order.canceled.count } => +1 do
       accept_confirm do
         within "tr", text: stock.ticker do
-          find("button i.fa-ban").click
+          find("[data-testid='cancel-order-button']").click
         end
       end
 

--- a/test/system/user_manages_orders_test.rb
+++ b/test/system/user_manages_orders_test.rb
@@ -17,7 +17,7 @@ class UserManagesOrdersTest < ApplicationSystemTestCase
 
     accept_confirm do
       within "tr", text: order.stock.company_name do
-        find("button i.fa-ban").click
+        find("[data-testid='cancel-order-button']").click
       end
     end
 
@@ -36,7 +36,7 @@ class UserManagesOrdersTest < ApplicationSystemTestCase
 
     accept_confirm do
       within "tr", text: order.stock.company_name do
-        find("button i.fa-ban").click
+        find("[data-testid='cancel-order-button']").click
       end
     end
 


### PR DESCRIPTION
## Summary
- Replaces fragile icon-based CSS selectors with reliable `data-testid` attributes
- Improves test readability and stability for action buttons
- Follows the same pattern established in PR #884 (portfolio view tests)

## Changes

### Views Updated
**`app/views/orders/index.html.erb`**
- Added `data-testid="edit-order-button"` to edit order link
- Added `data-testid="cancel-order-button"` to cancel order button

**`app/views/stocks/_index_row.html.erb`**
- Added `data-testid="buy-stock-button"` to buy stock link
- Added `data-testid="sell-stock-button"` to sell stock link

### Tests Updated
**`test/system/student_trading_flow_test.rb`**
- Updated edit order test: `find("i.fa-pencil")` → `find("[data-testid='edit-order-button']")`
- Updated cancel order test: `find("button i.fa-ban")` → `find("[data-testid='cancel-order-button']")`

**`test/system/user_manages_orders_test.rb`**
- Updated both cancel order tests to use `[data-testid='cancel-order-button']`

## Why This Matters

**Before:**
```ruby
find("button i.fa-ban").click  # Fragile: breaks if icon changes
```

**After:**
```ruby
find("[data-testid='cancel-order-button']").click  # Stable & readable
```

**Benefits:**
- ✅ Icon classes can change without breaking tests
- ✅ More readable and self-documenting
- ✅ Follows Rails/Capybara best practices
- ✅ Consistent with other test infrastructure

## Test Results
All system tests pass:
- `test/system/student_trading_flow_test.rb` ✅
- `test/system/user_manages_orders_test.rb` ✅
- RuboCop passes ✅

## Notes
- Buy/Sell button tests already use `click_on "Buy"` (text-based), so no changes needed
- Teacher edit/delete student buttons are out of scope for this issue

Resolves #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)