### PR TITLE
Fix: Enable trading for classroom in seed data

### DIFF
--- a/db/seeds/partials/classrooms.rb
+++ b/db/seeds/partials/classrooms.rb
@@ -1,1 +1,1 @@
-Classroom.find_or_create_by(name: "Smith's Sixth Grade", school_year: SchoolYear.first, grade: 6)
+Classroom.find_or_create_by(name: "Smith's Sixth Grade", school_year: SchoolYear.first, grade: 6, trading_enabled: true)


### PR DESCRIPTION
# Pull Request

## Summary
Fixes seed data failure by enabling trading for the seeded classroom. When PR #800 added `trading_enabled` with default `false`, the classroom seed wasn't updated, causing order creation to fail during `db:setup`.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/902

## Changes
- Set `trading_enabled: true` for classroom in `db/seeds/partials/classrooms.rb`

## Screenshots (if applicable)
N/A - seed data fix

## Checklist
- [x] Issue is assigned
- [x] Issue link added to PR description
- [x] Branch created from main
- [x] Commits are small and descriptive (1 commit)
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Root cause: PR #800 added trading validation but didn't update seed data
- Tested locally with `bin/dc rails db:reset` - seeds now run successfully
- This wasn't caught by CI because test environment has no seeds (intentional)