### PR TITLE
Fix confusing sell error message by removing 'Shares' prefix

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -67,7 +67,7 @@ class Order < ApplicationRecord
     return unless shares > current_shares
 
     formatted_shares = (current_shares % 1).zero? ? current_shares.to_i : current_shares
-    errors.add(:shares, "Cannot sell more shares than you own (#{formatted_shares} available)")
+    errors.add(:base, "Cannot sell more shares than you own (#{formatted_shares} available)")
   end
 
   def sufficient_funds_for_buy

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -128,7 +128,7 @@ class OrderTest < ActiveSupport::TestCase
     order = build(:order, action: :sell, user: user, stock: stock, shares: 10)
 
     assert_not order.valid?
-    assert_includes order.errors[:shares], "Cannot sell more shares than you own (5 available)"
+    assert_includes order.errors[:base], "Cannot sell more shares than you own (5 available)"
   end
 
   test "sell order validation prevents selling when no shares owned" do
@@ -139,7 +139,7 @@ class OrderTest < ActiveSupport::TestCase
     order = build(:order, action: :sell, user: user, stock: stock, shares: 1)
 
     assert_not order.valid?
-    assert_includes order.errors[:shares], "Cannot sell more shares than you own (0 available)"
+    assert_includes order.errors[:base], "Cannot sell more shares than you own (0 available)"
   end
 
   test "sell order validation with multiple portfolio_stock records" do
@@ -155,7 +155,7 @@ class OrderTest < ActiveSupport::TestCase
 
     order = build(:order, action: :sell, user: user, stock: stock, shares: 20)
     assert_not order.valid?
-    assert_includes order.errors[:shares], "Cannot sell more shares than you own (15 available)"
+    assert_includes order.errors[:base], "Cannot sell more shares than you own (15 available)"
   end
 
   test "buy order validation is not affected by sell validation" do


### PR DESCRIPTION
## Summary
Fixes confusing error message when trying to sell more shares than owned. The validation error was being added to `:shares` field, causing Rails to automatically prefix it with "Shares", resulting in the awkward message "Shares Cannot sell more shares than you own (5 available)".

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/922

## Changes
- Changed `errors.add(:shares, ...)` to `errors.add(:base, ...)` in Order model
- Updated all related tests to check `errors[:base]` instead of `errors[:shares]`

## Screenshots (if applicable)
<img width="1463" height="931" alt="Better0SharesErrorMsg" src="https://github.com/user-attachments/assets/380e3044-4faf-447d-bd6f-79f1d06208d2" />


## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
Simple fix - changed which field the error is added to, preventing Rails from adding unwanted prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>