### PR TITLE
Add admin years, resolves 930

### DIFF
--- a/app/controllers/admin_v2/years_controller.rb
+++ b/app/controllers/admin_v2/years_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module AdminV2
+  class YearsController < BaseController
+    before_action :set_year, only: %i[show edit update destroy]
+
+    def index
+      @years = apply_sorting(Year.all, default: "name")
+
+      @breadcrumbs = [
+        { label: "Years" }
+      ]
+    end
+
+    def show
+      @breadcrumbs = [
+        { label: "Years", path: admin_v2_years_path },
+        { label: @year.name }
+      ]
+    end
+
+    def new
+      @year = Year.new
+      @breadcrumbs = [
+        { label: "Years", path: admin_v2_years_path },
+        { label: "New Year" }
+      ]
+    end
+
+    def edit
+      @breadcrumbs = [
+        { label: "Years", path: admin_v2_years_path },
+        { label: @year.name, path: admin_v2_year_path(@year) },
+        { label: "Edit" }
+      ]
+    end
+
+    def create
+      @year = Year.new(year_params)
+
+      if @year.save
+        redirect_to admin_v2_year_path(@year), notice: t(".notice")
+      else
+        @breadcrumbs = [
+          { label: "Years", path: admin_v2_years_path },
+          { label: "New Year" }
+        ]
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def update
+      if @year.update(year_params)
+        redirect_to admin_v2_year_path(@year), notice: t(".notice")
+      else
+        @breadcrumbs = [
+          { label: "Years", path: admin_v2_years_path },
+          { label: @year.name, path: admin_v2_year_path(@year) },
+          { label: "Edit" }
+        ]
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      @year.destroy
+      redirect_to admin_v2_years_path, notice: t(".notice")
+    end
+
+    private
+
+    def set_year
+      @year = Year.find(params[:id])
+    end
+
+    def year_params
+      params.expect(year: [:name])
+    end
+  end
+end

--- a/app/views/admin_v2/dashboard/index.html.erb
+++ b/app/views/admin_v2/dashboard/index.html.erb
@@ -27,8 +27,16 @@
       </div>
       <ul class="space-y-2 text-sm">
         <li class="text-gray-600"><i class="fas fa-chalkboard w-4 mr-2"></i>Classrooms</li>
-        <li class="text-gray-600"><i class="fas fa-school w-4 mr-2"></i>Schools</li>
-        <li class="text-gray-600"><i class="fas fa-calendar-alt w-4 mr-2"></i>School Years</li>
+        <li>
+          <%= link_to admin_v2_schools_path, class: "text-blue-600 hover:text-blue-800 hover:underline" do %>
+            <i class="fas fa-school w-4 mr-2"></i>Schools
+          <% end %>
+        </li>
+        <li>
+          <%= link_to admin_v2_years_path, class: "text-blue-600 hover:text-blue-800 hover:underline" do %>
+            <i class="fas fa-calendar-alt w-4 mr-2"></i>School Years
+          <% end %>
+        </li>
         <li>
           <%= link_to admin_v2_grades_path, class: "text-blue-600 hover:text-blue-800 hover:underline" do %>
             <i class="fas fa-graduation-cap w-4 mr-2"></i>Grades

--- a/app/views/admin_v2/shared/_navigation.html.erb
+++ b/app/views/admin_v2/shared/_navigation.html.erb
@@ -21,7 +21,7 @@
         <i class="fas fa-school w-5 mr-3 text-gray-500"></i>
         Schools
       <% end %>
-      <%= link_to "#", class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 rounded-lg transition-colors" do %>
+      <%= link_to admin_v2_years_path, class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900 rounded-lg transition-colors" do %>
         <i class="fas fa-calendar-alt w-5 mr-3 text-gray-500"></i>
         School Years
       <% end %>

--- a/app/views/admin_v2/years/_form.html.erb
+++ b/app/views/admin_v2/years/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: @year, url: @year.persisted? ? admin_v2_year_path(@year) : admin_v2_years_path, builder: AdminV2::FormBuilder, class: "space-y-6" do |f| %>
+  <div class="bg-white shadow-sm ring-1 ring-gray-900/5 rounded-lg">
+    <div class="px-6 py-6">
+      <h3 class="text-lg font-medium text-gray-900 mb-6">Year Details</h3>
+
+      <%= f.text_field :name,
+                       label: "Name",
+                       hint: "Enter the year name (e.g., 2024 - 2025)",
+                       placeholder: "2024 - 2025" %>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-end gap-x-4">
+    <%= f.cancel_button "Cancel", url: @year.persisted? ? admin_v2_year_path(@year) : admin_v2_years_path %>
+    <%= f.submit_button @year.persisted? ? "Update Year" : "Create Year" %>
+  </div>
+<% end %>

--- a/app/views/admin_v2/years/edit.html.erb
+++ b/app/views/admin_v2/years/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="max-w-7xl mx-auto">
+  <%= admin_breadcrumbs(@breadcrumbs) %>
+
+  <div class="mb-6">
+    <h1 class="text-3xl font-bold text-gray-900">Edit Year</h1>
+    <p class="text-gray-600 mt-2"><%= @year.name %></p>
+  </div>
+
+  <%= render "form" %>
+</div>

--- a/app/views/admin_v2/years/index.html.erb
+++ b/app/views/admin_v2/years/index.html.erb
@@ -1,0 +1,19 @@
+<div class="max-w-7xl mx-auto">
+  <%= admin_breadcrumbs(@breadcrumbs) %>
+
+  <%= admin_table(
+        @years,
+        columns: [
+          { attribute: :id, label: "ID", sortable: true },
+          { attribute: :name, label: "Name", sortable: true },
+          { attribute: :created_at, label: "Created", sortable: true }
+        ],
+        title: "Years",
+        actions: link_to(
+          "New Year",
+          new_admin_v2_year_path,
+          class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700"
+        ),
+        empty_message: "No years found. Create your first year to get started."
+      ) %>
+</div>

--- a/app/views/admin_v2/years/new.html.erb
+++ b/app/views/admin_v2/years/new.html.erb
@@ -1,0 +1,9 @@
+<div class="max-w-7xl mx-auto">
+  <%= admin_breadcrumbs(@breadcrumbs) %>
+
+  <div class="mb-6">
+    <h1 class="text-3xl font-bold text-gray-900">New Year</h1>
+  </div>
+
+  <%= render "form" %>
+</div>

--- a/app/views/admin_v2/years/show.html.erb
+++ b/app/views/admin_v2/years/show.html.erb
@@ -1,0 +1,52 @@
+<div class="max-w-7xl mx-auto">
+  <%= admin_breadcrumbs(@breadcrumbs) %>
+
+  <div class="bg-white shadow-sm ring-1 ring-gray-900/5 rounded-lg mb-6">
+    <div class="px-6 py-6">
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-gray-900"><%= @year.name %></h2>
+        <div class="flex gap-3">
+          <%= link_to edit_admin_v2_year_path(@year),
+                      class: "inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50" do %>
+            <i class="fas fa-edit -ml-1 mr-2 h-5 w-5 text-gray-500"></i>
+            Edit
+          <% end %>
+          <%= link_to admin_v2_year_path(@year),
+                      data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this year?" },
+                      class: "inline-flex items-center px-4 py-2 border border-red-300 shadow-sm text-sm font-medium rounded-md text-red-700 bg-white hover:bg-red-50" do %>
+            <i class="fas fa-trash -ml-1 mr-2 h-5 w-5 text-red-500"></i>
+            Delete
+          <% end %>
+        </div>
+      </div>
+
+      <%= admin_show_attributes(
+            @year,
+            attributes: %i[id name created_at updated_at]
+          ) %>
+
+      <!-- Associated Schools -->
+      <% if @year.schools.any? %>
+        <div class="mt-6 pt-6 border-t border-gray-200">
+          <h3 class="text-sm font-medium text-gray-500 mb-3">Associated Schools</h3>
+          <ul class="space-y-2">
+            <% @year.schools.each do |school| %>
+              <li class="text-sm text-gray-900">
+                <%= school.name %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% else %>
+        <div class="mt-6 pt-6 border-t border-gray-200">
+          <p class="text-sm text-gray-500">No schools associated with this year yet.</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="flex gap-3">
+    <%= link_to "Back to Years", admin_v2_years_path,
+                class: "inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50" %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,13 @@ en:
         notice: School deleted successfully.
       update:
         notice: School updated successfully.
+    years:
+      create:
+        notice: Year created successfully.
+      destroy:
+        notice: Year deleted successfully.
+      update:
+        notice: Year updated successfully.
   announcements:
     not_found: Announcement not found.
   application:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     resources :announcements
     resources :grades
     resources :schools
+    resources :years
   end
 
   resources :orders do


### PR DESCRIPTION
Resolves #930 
  
Implements `AdminV2` interface for Years resource management, continuing the migration from Administrate to the in-house admin system.

  ### Changes

  - **Controller:** Created `AdminV2::YearsController` with full CRUD operations
    - Uses `apply_sorting` helper for consistent sorting behavior
    - Includes breadcrumb navigation throughout
    - Strong parameters with `params.expect(year: [:name])`
  - **Views**: Created complete view set for Years
    - Index page with sortable table (ID, Name, Created columns)
    - Show page displaying year details and associated schools
    - Reusable form partial with name field
    - New and edit pages
  - **Routes**: Added resources `:years` to `admin_v2` namespace
  - i18n: Added translations for create, update, and destroy flash messages
  - **Navigation:**
    - Updated sidebar navigation to link School Years to years index
    - Updated dashboard to make School Years and Schools clickable links

### Screenshots
<img width="1325" height="1016" alt="Screenshot 2025-12-23 at 5 20 02 PM" src="https://github.com/user-attachments/assets/39af3cac-7e49-443a-9a40-f63666102e6a" />

<img width="1363" height="635" alt="Screenshot 2025-12-23 at 5 20 08 PM" src="https://github.com/user-attachments/assets/70a93aeb-acce-4742-8ca3-735802195d1a" />

<img width="1354" height="478" alt="Screenshot 2025-12-23 at 5 20 17 PM" src="https://github.com/user-attachments/assets/ecf2216e-f6dc-4d18-a29f-34e97bfc8c2d" />

<img width="1357" height="445" alt="Screenshot 2025-12-23 at 5 20 29 PM" src="https://github.com/user-attachments/assets/66de9abc-e44b-4a5d-a128-f78c548971c1" />
