### PR TITLE
Fix portfolio values not showing on class view

### DIFF
--- a/app/models/portfolio.rb
+++ b/app/models/portfolio.rb
@@ -35,6 +35,10 @@ class Portfolio < ApplicationRecord
     calculate_total_value_cents / 100.0
   end
 
+  def holdings_value
+    holdings_value_cents / 100.0
+  end
+
   def holdings_value_cents
     portfolio_stocks.joins(:stock).sum(
       "portfolio_stocks.shares * stocks.price_cents"

--- a/app/views/classrooms/_classroom_students_table.html.erb
+++ b/app/views/classrooms/_classroom_students_table.html.erb
@@ -37,7 +37,7 @@
               <% end %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-medium">
-              <%= number_to_currency(student.portfolio&.current_position || 0) %>
+              <%= number_to_currency(student.portfolio&.holdings_value || 0) %>
             </td>
             <% if @can_manage_students %>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-medium">


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes the classroom show page where the student portfolio value was always displayed as $0. It now correctly calculates and displays each student’s portfolio value based on their current stock holdings and stock prices.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/923

## Changes
- Added `holdings_value` helper method on the `Portfolio` model to calculate a student’s portfolio value from current holdings.
- Updated `app/views/classrooms/_classroom_students_table.html.erb` view page to display the calculated portfolio value.
- Ensured values are properly formatted as currency.

## Screenshots (if applicable)
<img width="1677" height="305" alt="Screenshot 2025-12-24 at 11-47-42 StocksInTheFuture" src="https://github.com/user-attachments/assets/d3d4ee48-13ff-4ed7-b4ef-ee88d15985c5" />

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
