### PR TITLE
Fix to create the Grade manually before assigning it to a Classroom

### DIFF
--- a/db/seeds/partials/classrooms.rb
+++ b/db/seeds/partials/classrooms.rb
@@ -1,1 +1,3 @@
-Classroom.find_or_create_by(name: "Smith's Sixth Grade", school_year: SchoolYear.first, grade: 6, trading_enabled: true)
+classroom = Classroom.find_or_create_by!(name: "Smith's Sixth Grade", school_year: SchoolYear.first, trading_enabled: true)
+grade = Grade.find_by(level: 6)
+classroom.grades << grade if grade && !classroom.grades.include?(grade)


### PR DESCRIPTION
# Pull Request

## Summary
Seed files were busted. This updates them to allow for a db:reset

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/967

## Changes
- Add Grade creation for classrooms

## Screenshots (if applicable)

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [ ] Ran tests and all tests pass
- [ ] CI checks passing
- [ ] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
