### PR TITLE
Add app/facades to the autoloads paths list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,9 +23,10 @@ module StocksInTheFuture
 
     config.active_job.queue_adapter = :solid_queue
 
-    # Add form_builders and presenters to autoload paths
+    # Add form_builders, presenters, and facades to autoload paths
     config.autoload_paths << Rails.root.join("app/form_builders")
     config.autoload_paths << Rails.root.join("app/presenters")
+    config.autoload_paths << Rails.root.join("app/facades")
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Classroom Show page is failing because it can't find the Facade
This update adds the facades path to the autoloads paths so the show page can find the ClassroomFacade