### PR TITLE
Fix NoMethodError in AdminV2 Classrooms for removed grade attribute

### DIFF
--- a/app/views/admin_v2/classrooms/index.html.erb
+++ b/app/views/admin_v2/classrooms/index.html.erb
@@ -21,7 +21,7 @@
               <%= sort_link(:name, "Name") %>
             </th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-              <%= sort_link(:grade, "Grade") %>
+              Grade
             </th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
               School Year
@@ -40,7 +40,7 @@
         <tbody class="divide-y divide-gray-200 bg-white">
           <% if @classrooms.any? %>
             <% @classrooms.each do |classroom| %>
-              <tr class="hover:bg-gray-50 transition-colors">
+              <tr id="<%= dom_id(classroom) %>" class="hover:bg-gray-50 transition-colors">
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900">
                   <%= classroom.id %>
                 </td>

--- a/app/views/admin_v2/classrooms/show.html.erb
+++ b/app/views/admin_v2/classrooms/show.html.erb
@@ -21,10 +21,8 @@
         </div>
       </div>
 
-      <%= admin_show_attributes(
-            @classroom,
-            attributes: %i[id name grade archived trading_enabled school_year created_at updated_at]
-          ) %>
+      <%= admin_show_attributes(@classroom,
+                                attributes: %i[id name grades_display archived trading_enabled school_year created_at updated_at]) %>
 
       <!-- Associated Students -->
       <% if @classroom.students.any? %>

--- a/app/views/admin_v2/shared/_show_attributes.html.erb
+++ b/app/views/admin_v2/shared/_show_attributes.html.erb
@@ -2,7 +2,7 @@
   <div class="px-4 py-5 sm:px-6">
     <dl class="divide-y divide-gray-200">
       <% attributes.each do |attribute| %>
-        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+        <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4" data-testid="<%= attribute %>">
           <dt class="text-sm font-medium text-gray-500">
             <%= attribute.to_s.humanize %>
           </dt>


### PR DESCRIPTION
# Pull Request

## Summary

Allow classrooms to be displayed in Admin V2

## Related Issue
Resolves #984

## Changes
1. Fixed NoMethodError by changing :grade to :grades_display in show view    
2. Removed grade sort link from index (not feasible with many-to-many)       
3. Added DOM IDs and data-testid attributes for testing                      
4. Added/updated tests for index and show pages
5. Fixed all tests in `test/controllers/admin_v2/classrooms_controller_test.rb`

## Screenshots (if applicable)

## Checklist
- [ ] Issue is assigned (commenting on the issue page is needed)
- [ ] Issue link added to the PR's description
- [ ] Branch created from main
- [ ] Commits are small and descriptive
- [ ] Ran linter and fixed issues
- [ ] Ran tests and all tests pass
- [ ] CI checks passing
- [ ] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
