### PR TITLE
Enforce first method argument line breaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Exclude:
+    - 'app/models/order.rb'
     - 'spec/**/*'
     - 'test/**/*'
 
@@ -72,3 +73,12 @@ Metrics/ParameterLists:
 
 Naming/MethodParameterName:
   MinNameLength: 2
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent

--- a/app/controllers/admin_v2/stocks_controller.rb
+++ b/app/controllers/admin_v2/stocks_controller.rb
@@ -78,28 +78,30 @@ module AdminV2
 
     # rubocop:disable Metrics/MethodLength
     def stock_params
-      params.expect(stock: %i[
-                      ticker
-                      company_name
-                      company_website
-                      stock_exchange
-                      description
-                      price_cents
-                      yesterday_price_cents
-                      employees
-                      industry
-                      cash_flow
-                      debt
-                      debt_to_equity
-                      profit_margin
-                      sales_growth
-                      industry_avg_debt_to_equity
-                      industry_avg_profit_margin
-                      industry_avg_sales_growth
-                      management
-                      competitor_names
-                      archived
-                    ])
+      params.expect(
+        stock: %i[
+          ticker
+          company_name
+          company_website
+          stock_exchange
+          description
+          price_cents
+          yesterday_price_cents
+          employees
+          industry
+          cash_flow
+          debt
+          debt_to_equity
+          profit_margin
+          sales_growth
+          industry_avg_debt_to_equity
+          industry_avg_profit_margin
+          industry_avg_sales_growth
+          management
+          competitor_names
+          archived
+        ]
+      )
     end
     # rubocop:enable Metrics/MethodLength
   end

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -103,8 +103,10 @@ class ClassroomsController < ApplicationController
       total_portfolio_value: students.includes(:portfolio).sum do |student|
         student.portfolio&.calculate_total_value || 0
       end,
-      recent_orders_count: Order.joins(:user).where(users: { classroom: @classroom }).where("orders.created_at > ?",
-                                                                                            1.week.ago).count
+      recent_orders_count: Order.joins(:user).where(users: { classroom: @classroom }).where(
+        "orders.created_at > ?",
+        1.week.ago
+      ).count
     }
   end
 

--- a/app/form_builders/admin_v2/form_builder.rb
+++ b/app/form_builders/admin_v2/form_builder.rb
@@ -57,13 +57,15 @@ module AdminV2
         value = object.public_send(attribute)
         display_value = value ? (value * multiplier).round(decimals) : nil
 
-        number_field(attribute,
-                     options.merge(
-                       value: display_value,
-                       step: (1.0 / (10**decimals)),
-                       class: input_class(attribute),
-                       data: { currency_multiplier: (1.0 / multiplier).to_i }
-                     ))
+        number_field(
+          attribute,
+          options.merge(
+            value: display_value,
+            step: (1.0 / (10**decimals)),
+            class: input_class(attribute),
+            data: { currency_multiplier: (1.0 / multiplier).to_i }
+          )
+        )
       end
     end
 
@@ -102,9 +104,11 @@ module AdminV2
       include_blank = options.delete(:include_blank)
 
       field_wrapper(attribute, options) do
-        select(attribute, collection,
-               { include_blank: include_blank },
-               input_options(attribute, options))
+        select(
+          attribute, collection,
+          { include_blank: include_blank },
+          input_options(attribute, options)
+        )
       end
     end
 
@@ -115,8 +119,10 @@ module AdminV2
 
       @template.content_tag(:div, class: "relative flex items-start py-4") do
         @template.content_tag(:div, class: "flex h-6 items-center") do
-          check_box(attribute,
-                    class: "h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600")
+          check_box(
+            attribute,
+            class: "h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600"
+          )
         end +
           @template.content_tag(:div, class: "ml-3 text-sm leading-6") do
             label(attribute, label_text, class: "font-medium text-gray-900") +
@@ -169,9 +175,11 @@ module AdminV2
       end
 
       field_wrapper(attribute, options) do
-        select(attribute, choices,
-               { include_blank: include_blank },
-               input_options(attribute, options))
+        select(
+          attribute, choices,
+          { include_blank: include_blank },
+          input_options(attribute, options)
+        )
       end
     end
 

--- a/app/helpers/admin_v2_helper.rb
+++ b/app/helpers/admin_v2_helper.rb
@@ -64,11 +64,15 @@ module AdminV2Helper
   # @return [String] HTML badge
   def boolean_badge(value)
     if value
-      content_tag(:span, "Yes",
-                  class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800") # rubocop:disable Layout/LineLength
+      content_tag(
+        :span, "Yes",
+        class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
+      )
     else
-      content_tag(:span, "No",
-                  class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800") # rubocop:disable Layout/LineLength
+      content_tag(
+        :span, "No",
+        class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800"
+      )
     end
   end
 
@@ -84,10 +88,15 @@ module AdminV2Helper
     url = url_for(sort: column, direction: direction, only_path: true)
 
     link_to url, class: "group inline-flex items-center" do
-      safe_join([
-                  label,
-                  content_tag(:span, icon, class: "ml-2 flex-none rounded text-gray-400 group-hover:text-gray-500")
-                ])
+      safe_join(
+        [
+          label,
+          content_tag(
+            :span, icon,
+            class: "ml-2 flex-none rounded text-gray-400 group-hover:text-gray-500"
+          )
+        ]
+      )
     end
   end
 
@@ -214,10 +223,12 @@ module AdminV2Helper
     link_to toggle_archive_admin_v2_classroom_path(classroom),
             data: { turbo_method: :patch, turbo_confirm: "Are you sure you want to activate this classroom?" },
             class: button_class do
-      safe_join([
-                  content_tag(:i, "", class: "fas fa-check-circle -ml-1 mr-2 h-5 w-5 text-green-500"),
-                  "Activate"
-                ])
+      safe_join(
+        [
+          content_tag(:i, "", class: "fas fa-check-circle -ml-1 mr-2 h-5 w-5 text-green-500"),
+          "Activate"
+        ]
+      )
     end
   end
 
@@ -227,10 +238,12 @@ module AdminV2Helper
     link_to toggle_archive_admin_v2_classroom_path(classroom),
             data: { turbo_method: :patch, turbo_confirm: "Are you sure you want to archive this classroom?" },
             class: button_class do
-      safe_join([
-                  content_tag(:i, "", class: "fas fa-archive -ml-1 mr-2 h-5 w-5 text-yellow-500"),
-                  "Archive"
-                ])
+      safe_join(
+        [
+          content_tag(:i, "", class: "fas fa-archive -ml-1 mr-2 h-5 w-5 text-yellow-500"),
+          "Archive"
+        ]
+      )
     end
   end
 end

--- a/app/helpers/components/textarea_helper.rb
+++ b/app/helpers/components/textarea_helper.rb
@@ -3,8 +3,10 @@
 module Components
   module TextareaHelper
     def render_textarea(name:, label: false, id: nil, value: nil, **options)
-      options.reverse_merge!(rows: 3, required: false, disabled: false,
-                             readonly: false, class: "", label: false, placeholder: "Type here...")
+      options.reverse_merge!(
+        rows: 3, required: false, disabled: false,
+        readonly: false, class: "", label: false, placeholder: "Type here..."
+      )
       render partial: "components/ui/textarea", locals: {
         label:,
         name:,

--- a/app/jobs/monthly_portfolio_snapshot_job.rb
+++ b/app/jobs/monthly_portfolio_snapshot_job.rb
@@ -9,8 +9,8 @@ class MonthlyPortfolioSnapshotJob < ApplicationJob
     Rails.logger.info "[RECURRING JOB] Target date: #{target_date}"
 
     Portfolio.includes(:portfolio_stocks, :stocks)
-             .find_in_batches(batch_size: batch_size) do |batch|
-               batch.each { |portfolio| create_snapshot_for_portfolio(portfolio, target_date) }
+      .find_in_batches(batch_size: batch_size) do |batch|
+        batch.each { |portfolio| create_snapshot_for_portfolio(portfolio, target_date) }
     end
 
     Rails.logger.info "[RECURRING JOB] MonthlyPortfolioSnapshotJob completed successfully"

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -35,8 +35,8 @@ class Classroom < ApplicationRecord
   # @return [ActiveRecord::Relation<Student>]
   def current_students
     enrolled_students.joins(:classroom_enrollments)
-                     .merge(classroom_enrollments.current)
-                     .distinct
+      .merge(classroom_enrollments.current)
+      .distinct
   end
 
   # Get historically enrolled students (students with past enrollments)
@@ -44,16 +44,16 @@ class Classroom < ApplicationRecord
   # @return [ActiveRecord::Relation<Student>]
   def historical_students
     enrolled_students.joins(:classroom_enrollments)
-                     .merge(classroom_enrollments.historical)
-                     .distinct
+      .merge(classroom_enrollments.historical)
+      .distinct
   end
 
   def grades_display
     values = classroom_grades
-             .joins(:grade)
-             .pluck("grades.level")
-             .uniq
-             .sort
+      .joins(:grade)
+      .pluck("grades.level")
+      .uniq
+      .sort
     return if values.empty?
 
     if values.one?

--- a/app/models/classroom_enrollment.rb
+++ b/app/models/classroom_enrollment.rb
@@ -36,8 +36,8 @@ class ClassroomEnrollment < ApplicationRecord
   def make_primary!
     transaction do
       ClassroomEnrollment.where(student: student, primary: true)
-                         .where.not(id: id)
-                         .find_each { |enrollment| enrollment.update!(primary: false) }
+        .where.not(id: id)
+        .find_each { |enrollment| enrollment.update!(primary: false) }
       update!(primary: true)
     end
     self
@@ -79,8 +79,8 @@ class ClassroomEnrollment < ApplicationRecord
     return if student_id.blank?
 
     existing = ClassroomEnrollment.where(student_id: student_id, primary: true)
-                                  .where.not(id: id)
-                                  .exists?
+      .where.not(id: id)
+      .exists?
 
     errors.add(:primary, "student can only have one primary enrollment") if existing
   end

--- a/app/models/earnings_summary.rb
+++ b/app/models/earnings_summary.rb
@@ -35,8 +35,8 @@ class EarningsSummary
 
   def sum_by_reason(reason)
     portfolio.portfolio_transactions
-             .deposits
-             .where(reason: reason)
-             .sum(:amount_cents)
+      .deposits
+      .where(reason: reason)
+      .sum(:amount_cents)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -99,8 +99,10 @@ class Order < ApplicationRecord
 
     formatted_balance = format_money(current_balance_cents)
     formatted_cost = format_money(total_cost)
-    errors.add(:shares,
-               "Insufficient funds. You have #{formatted_balance} but need #{formatted_cost}")
+    errors.add(
+      :shares,
+      "Insufficient funds. You have #{formatted_balance} but need #{formatted_cost}"
+    )
   end
 
   def order_is_pending

--- a/app/models/quarter.rb
+++ b/app/models/quarter.rb
@@ -30,12 +30,12 @@ class Quarter < ApplicationRecord
 
       if next_year
         Quarter.joins(school_year: %i[school year])
-               .where(
-                 school_years: { school: school_year.school },
-                 years: { id: next_year.id },
-                 number: 1
-               )
-               .first
+          .where(
+            school_years: { school: school_year.school },
+            years: { id: next_year.id },
+            number: 1
+          )
+          .first
       end
     end
   end
@@ -46,12 +46,12 @@ class Quarter < ApplicationRecord
 
       if previous_year
         Quarter.joins(school_year: %i[school year])
-               .where(
-                 school_years: { school: school_year.school },
-                 years: { id: previous_year.id },
-                 number: 4
-               )
-               .first
+          .where(
+            school_years: { school: school_year.school },
+            years: { id: previous_year.id },
+            number: 4
+          )
+          .first
       end
     end
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -23,8 +23,8 @@ class Student < User
   # @return [ActiveRecord::Relation<Classroom>]
   def current_classrooms
     classrooms.joins(:classroom_enrollments)
-              .merge(classroom_enrollments.current)
-              .distinct
+      .merge(classroom_enrollments.current)
+      .distinct
   end
 
   # Get the student's primary enrollment

--- a/app/services/execute_order.rb
+++ b/app/services/execute_order.rb
@@ -43,8 +43,8 @@ class ExecuteOrder
   def create_portfolio_stock
     share_amount = order.sell? ? -shares : shares
     @portfolio_stock = portfolio
-                       .portfolio_stocks
-                       .create!(stock:, shares: share_amount, purchase_price: stock.current_price)
+      .portfolio_stocks
+      .create!(stock:, shares: share_amount, purchase_price: stock.current_price)
   end
 
   def update_order_status

--- a/app/views/admin/students/index.html.erb
+++ b/app/views/admin/students/index.html.erb
@@ -23,11 +23,13 @@ It renders the `_table` partial to display details about the resources.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
 
-<%= render("index_header",
-           resources: resources,
-           search_term: search_term,
-           page: page,
-           show_search_bar: show_search_bar) %>
+<%= render(
+      "index_header",
+      resources: resources,
+      search_term: search_term,
+      page: page,
+      show_search_bar: show_search_bar
+    ) %>
 
 <%= content_for(:before_main) %>
 

--- a/app/views/admin_v2/classrooms/show.html.erb
+++ b/app/views/admin_v2/classrooms/show.html.erb
@@ -21,8 +21,10 @@
         </div>
       </div>
 
-      <%= admin_show_attributes(@classroom,
-                                attributes: %i[id name grades_display archived trading_enabled school_year created_at updated_at]) %>
+      <%= admin_show_attributes(
+            @classroom,
+            attributes: %i[id name grades_display archived trading_enabled school_year created_at updated_at]
+          ) %>
 
       <!-- Associated Students -->
       <% if @classroom.students.any? %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,9 +1,11 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase) %>
+      <%= I18n.t(
+            "errors.messages.not_saved",
+            count: resource.errors.count,
+            resource: resource.class.model_name.human.downcase
+          ) %>
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,10 +1,12 @@
-<%= form_with(model: order,
-              class: "w-full max-w-md mx-auto",
-              data: {
-                controller: "order-form",
-                order_form_current_price_value: order.stock.current_price,
-                turbo_frame: "_top"
-              }) do |form| %>
+<%= form_with(
+      model: order,
+      class: "w-full max-w-md mx-auto",
+      data: {
+        controller: "order-form",
+        order_form_current_price_value: order.stock.current_price,
+        turbo_frame: "_top"
+      }
+    ) do |form| %>
 
   <!-- Error Messages -->
   <% if order.errors.any? %>

--- a/test/controllers/grade_books_controller_test.rb
+++ b/test/controllers/grade_books_controller_test.rb
@@ -133,8 +133,10 @@ class GradeBooksControllerTest < ActionDispatch::IntegrationTest
 
     # Create new grade book for second quarter with incomplete grades
     new_grade_book = create(:grade_book, classroom: @classroom, quarter: @second_quarter)
-    create(:grade_entry, grade_book: new_grade_book, user: @student,
-                         math_grade: nil, reading_grade: nil, attendance_days: 30)
+    create(
+      :grade_entry, grade_book: new_grade_book, user: @student,
+                    math_grade: nil, reading_grade: nil, attendance_days: 30
+    )
 
     post finalize_classroom_grade_book_path(@classroom, new_grade_book)
 
@@ -156,8 +158,10 @@ class GradeBooksControllerTest < ActionDispatch::IntegrationTest
 
     # Create new grade book for second quarter with complete grades
     new_grade_book = create(:grade_book, classroom: @classroom, quarter: @second_quarter)
-    create(:grade_entry, grade_book: new_grade_book, user: @student,
-                         math_grade: "A", reading_grade: "A", attendance_days: 30)
+    create(
+      :grade_entry, grade_book: new_grade_book, user: @student,
+                    math_grade: "A", reading_grade: "A", attendance_days: 30
+    )
 
     post finalize_classroom_grade_book_path(@classroom, new_grade_book)
 
@@ -179,8 +183,10 @@ class GradeBooksControllerTest < ActionDispatch::IntegrationTest
 
     # Create new grade book for second quarter with complete grades
     new_grade_book = create(:grade_book, classroom: @classroom, quarter: @second_quarter)
-    create(:grade_entry, grade_book: new_grade_book, user: @student,
-                         math_grade: "A", reading_grade: "A", attendance_days: 30)
+    create(
+      :grade_entry, grade_book: new_grade_book, user: @student,
+                    math_grade: "A", reading_grade: "A", attendance_days: 30
+    )
 
     post finalize_classroom_grade_book_path(@classroom, new_grade_book)
 

--- a/test/controllers/orders_controller_test.rb
+++ b/test/controllers/orders_controller_test.rb
@@ -129,8 +129,10 @@ class OrdersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "cancel route exists" do
-    assert_routing({ path: "orders/1/cancel", method: "patch" },
-                   { controller: "orders", action: "cancel", id: "1" })
+    assert_routing(
+      { path: "orders/1/cancel", method: "patch" },
+      { controller: "orders", action: "cancel", id: "1" }
+    )
   end
 
   test "cancel with unauthorized user" do

--- a/test/facades/classroom_facade_test.rb
+++ b/test/facades/classroom_facade_test.rb
@@ -57,15 +57,19 @@ class ClassroomFacadeTest < ActiveSupport::TestCase
     current_student = create(:student, :without_enrollment)
     historical_student = create(:student, :without_enrollment)
 
-    create(:classroom_enrollment,
-           student: current_student,
-           classroom: classroom,
-           unenrolled_at: nil)
-    create(:classroom_enrollment,
-           student: historical_student,
-           classroom: classroom,
-           enrolled_at: 2.weeks.ago,
-           unenrolled_at: 1.week.ago)
+    create(
+      :classroom_enrollment,
+      student: current_student,
+      classroom: classroom,
+      unenrolled_at: nil
+    )
+    create(
+      :classroom_enrollment,
+      student: historical_student,
+      classroom: classroom,
+      enrolled_at: 2.weeks.ago,
+      unenrolled_at: 1.week.ago
+    )
 
     facade = ClassroomFacade.new(classroom)
     students = facade.students

--- a/test/factories/orders.rb
+++ b/test/factories/orders.rb
@@ -39,11 +39,13 @@ FactoryBot.define do
 
   trait :with_sufficient_shares do
     after(:create) do |order|
-      create(:portfolio_stock,
-             portfolio: order.user.portfolio,
-             stock: order.stock,
-             shares: 100, # Plenty of shares for testing
-             purchase_price: order.stock.price_cents)
+      create(
+        :portfolio_stock,
+        portfolio: order.user.portfolio,
+        stock: order.stock,
+        shares: 100, # Plenty of shares for testing
+        purchase_price: order.stock.price_cents
+      )
     end
   end
 end

--- a/test/integration/navbar_policy_visibility_test.rb
+++ b/test/integration/navbar_policy_visibility_test.rb
@@ -9,8 +9,10 @@ class NavbarPolicyVisibilityTest < ActionDispatch::IntegrationTest
     classroom = create(:classroom)
     @student = User.create!(username: "student", type: "Student", password: "password", classroom: classroom)
     @teacher = User.create!(username: "teacher", type: "Teacher", password: "password", email: "teacher@test.com")
-    @admin = User.create!(username: "admin", type: "Teacher", admin: true, password: "password",
-                          email: "admin@test.com")
+    @admin = User.create!(
+      username: "admin", type: "Teacher", admin: true, password: "password",
+      email: "admin@test.com"
+    )
     @portfolio = Portfolio.create!(user: @student)
   end
 

--- a/test/models/classroom_enrollment_test.rb
+++ b/test/models/classroom_enrollment_test.rb
@@ -36,18 +36,22 @@ class ClassroomEnrollmentTest < ActiveSupport::TestCase
   end
 
   test "unenrolled_at must be after enrolled_at" do
-    enrollment = build(:classroom_enrollment,
-                       enrolled_at: 1.day.ago,
-                       unenrolled_at: 2.days.ago)
+    enrollment = build(
+      :classroom_enrollment,
+      enrolled_at: 1.day.ago,
+      unenrolled_at: 2.days.ago
+    )
     assert_not enrollment.valid?
     assert_includes enrollment.errors[:unenrolled_at], "must be after enrolled_at"
   end
 
   test "unenrolled_at can be equal to enrolled_at" do
     time = Time.current
-    enrollment = build(:classroom_enrollment,
-                       enrolled_at: time,
-                       unenrolled_at: time)
+    enrollment = build(
+      :classroom_enrollment,
+      enrolled_at: time,
+      unenrolled_at: time
+    )
     assert enrollment.valid?
   end
 
@@ -121,8 +125,10 @@ class ClassroomEnrollmentTest < ActiveSupport::TestCase
 
   test "unenroll! sets unenrolled_at to current time by default" do
     student = create(:student, :without_enrollment)
-    enrollment = create(:classroom_enrollment, student: student, enrolled_at: 1.hour.ago, unenrolled_at: nil,
-                                               primary: true)
+    enrollment = create(
+      :classroom_enrollment, student: student, enrolled_at: 1.hour.ago, unenrolled_at: nil,
+                             primary: true
+    )
 
     freeze_time do
       enrollment.unenroll!

--- a/test/models/portfolio_test.rb
+++ b/test/models/portfolio_test.rb
@@ -35,15 +35,19 @@ class PortfolioTest < ActiveSupport::TestCase
     # successful completed stock purchase, should decrease cash_balance
     # -$5.00
     buy_order = create(:order, :completed, :buy, stock: stock, shares: 5, user: user)
-    create(:portfolio_transaction, :debit, portfolio: portfolio, amount_cents: 5_00,
-                                           order: buy_order)
+    create(
+      :portfolio_transaction, :debit, portfolio: portfolio, amount_cents: 5_00,
+                                      order: buy_order
+    )
     create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 5, purchase_price: 100)
 
     # successful completed stock sale, should increase cash_balance
     #  # +$6.00
     sell_order = create(:order, :completed, :sell, stock: stock, shares: 6, user: user)
-    create(:portfolio_transaction, :credit, portfolio: portfolio, amount_cents: 6_00,
-                                            order: sell_order)
+    create(
+      :portfolio_transaction, :credit, portfolio: portfolio, amount_cents: 6_00,
+                                       order: sell_order
+    )
     create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: -6, purchase_price: 100)
 
     # withdrawal from the account, should decrease cash_balance
@@ -173,10 +177,12 @@ class PortfolioTest < ActiveSupport::TestCase
     portfolio = create(:portfolio)
 
     15.times do |i|
-      create(:portfolio_snapshot,
-             portfolio: portfolio,
-             date: (14 - i).months.ago.beginning_of_month.to_date,
-             worth_cents: (100 + (i * 10)) * 100)
+      create(
+        :portfolio_snapshot,
+        portfolio: portfolio,
+        date: (14 - i).months.ago.beginning_of_month.to_date,
+        worth_cents: (100 + (i * 10)) * 100
+      )
     end
 
     result = portfolio.chart_data

--- a/test/models/student_test.rb
+++ b/test/models/student_test.rb
@@ -53,15 +53,19 @@ class StudentTest < ActiveSupport::TestCase
     classroom1 = create(:classroom)
     classroom2 = create(:classroom)
 
-    current = create(:classroom_enrollment,
-                     student: student,
-                     classroom: classroom1,
-                     unenrolled_at: nil)
-    historical = create(:classroom_enrollment,
-                        student: student,
-                        classroom: classroom2,
-                        enrolled_at: 2.days.ago,
-                        unenrolled_at: 1.day.ago)
+    current = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom1,
+      unenrolled_at: nil
+    )
+    historical = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom2,
+      enrolled_at: 2.days.ago,
+      unenrolled_at: 1.day.ago
+    )
 
     assert_includes student.current_enrollments, current
     assert_not_includes student.current_enrollments, historical
@@ -73,19 +77,25 @@ class StudentTest < ActiveSupport::TestCase
     classroom2 = create(:classroom)
     classroom3 = create(:classroom)
 
-    create(:classroom_enrollment,
-           student: student,
-           classroom: classroom1,
-           unenrolled_at: nil)
-    create(:classroom_enrollment,
-           student: student,
-           classroom: classroom2,
-           unenrolled_at: nil)
-    create(:classroom_enrollment,
-           student: student,
-           classroom: classroom3,
-           enrolled_at: 2.days.ago,
-           unenrolled_at: 1.day.ago)
+    create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom1,
+      unenrolled_at: nil
+    )
+    create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom2,
+      unenrolled_at: nil
+    )
+    create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom3,
+      enrolled_at: 2.days.ago,
+      unenrolled_at: 1.day.ago
+    )
 
     assert_includes student.current_classrooms, classroom1
     assert_includes student.current_classrooms, classroom2
@@ -97,14 +107,18 @@ class StudentTest < ActiveSupport::TestCase
     classroom1 = create(:classroom)
     classroom2 = create(:classroom)
 
-    primary = create(:classroom_enrollment,
-                     student: student,
-                     classroom: classroom1,
-                     primary: true)
-    create(:classroom_enrollment,
-           student: student,
-           classroom: classroom2,
-           primary: false)
+    primary = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom1,
+      primary: true
+    )
+    create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom2,
+      primary: false
+    )
 
     assert_equal primary, student.primary_enrollment
   end
@@ -113,10 +127,12 @@ class StudentTest < ActiveSupport::TestCase
     student = create(:student, :without_enrollment)
     classroom = create(:classroom)
 
-    create(:classroom_enrollment,
-           student: student,
-           classroom: classroom,
-           primary: true)
+    create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom,
+      primary: true
+    )
 
     assert_equal classroom, student.primary_classroom
   end
@@ -171,10 +187,12 @@ class StudentTest < ActiveSupport::TestCase
     classroom1 = create(:classroom)
     classroom2 = create(:classroom)
 
-    old_primary = create(:classroom_enrollment,
-                         student: student,
-                         classroom: classroom1,
-                         primary: true)
+    old_primary = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom1,
+      primary: true
+    )
 
     student.enroll_in!(classroom2, primary: true)
 
@@ -194,9 +212,11 @@ class StudentTest < ActiveSupport::TestCase
   test "unenroll_from! sets unenrolled_at on enrollment" do
     student = create(:student)
     classroom = create(:classroom)
-    enrollment = create(:classroom_enrollment,
-                        student: student,
-                        classroom: classroom)
+    enrollment = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom
+    )
 
     student.unenroll_from!(classroom)
 
@@ -206,10 +226,12 @@ class StudentTest < ActiveSupport::TestCase
   test "unenroll_from! sets unenrolled_at to current time by default" do
     student = create(:student, :without_enrollment)
     classroom = create(:classroom)
-    enrollment = create(:classroom_enrollment,
-                        student: student,
-                        classroom: classroom,
-                        enrolled_at: 1.hour.ago)
+    enrollment = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom,
+      enrolled_at: 1.hour.ago
+    )
 
     freeze_time do
       student.unenroll_from!(classroom)
@@ -220,10 +242,12 @@ class StudentTest < ActiveSupport::TestCase
   test "unenroll_from! accepts custom unenrollment time" do
     student = create(:student, :without_enrollment)
     classroom = create(:classroom)
-    enrollment = create(:classroom_enrollment,
-                        student: student,
-                        classroom: classroom,
-                        enrolled_at: 2.weeks.ago)
+    enrollment = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom,
+      enrolled_at: 2.weeks.ago
+    )
     custom_time = 1.week.ago
 
     student.unenroll_from!(classroom, unenrolled_at: custom_time)
@@ -234,14 +258,18 @@ class StudentTest < ActiveSupport::TestCase
   test "unenroll_from! handles multiple enrollments for same classroom" do
     student = create(:student)
     classroom = create(:classroom)
-    enrollment1 = create(:classroom_enrollment,
-                         student: student,
-                         classroom: classroom,
-                         enrolled_at: 1.month.ago)
-    enrollment2 = create(:classroom_enrollment,
-                         student: student,
-                         classroom: classroom,
-                         enrolled_at: 2.weeks.ago)
+    enrollment1 = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom,
+      enrolled_at: 1.month.ago
+    )
+    enrollment2 = create(
+      :classroom_enrollment,
+      student: student,
+      classroom: classroom,
+      enrolled_at: 2.weeks.ago
+    )
 
     student.unenroll_from!(classroom)
 

--- a/test/policies/portfolio_policy_test.rb
+++ b/test/policies/portfolio_policy_test.rb
@@ -7,8 +7,10 @@ class PortfolioPolicyTest < ActiveSupport::TestCase
     @classroom = create(:classroom)
     @other_classroom = create(:classroom)
     @student = User.create!(username: "student", type: "Student", password: "password", classroom: @classroom)
-    @other_student = User.create!(username: "other_student", type: "Student", password: "password",
-                                  classroom: @other_classroom)
+    @other_student = User.create!(
+      username: "other_student", type: "Student", password: "password",
+      classroom: @other_classroom
+    )
 
     @teacher = create(:teacher)
     @admin = create(:admin)

--- a/test/services/distribute_earnings_test.rb
+++ b/test/services/distribute_earnings_test.rb
@@ -36,21 +36,25 @@ class DistributeEarningsTest < ActiveSupport::TestCase
     classroom = create(:classroom)
 
     previous_grade_book = create(:grade_book, quarter: previous_quarter, classroom: classroom)
-    create(:grade_entry,
-           grade_book: previous_grade_book,
-           user: student,
-           attendance_days: 6,
-           math_grade: "C",
-           reading_grade: "C")
+    create(
+      :grade_entry,
+      grade_book: previous_grade_book,
+      user: student,
+      attendance_days: 6,
+      math_grade: "C",
+      reading_grade: "C"
+    )
     previous_grade_book.completed!
 
     current_grade_book = create(:grade_book, quarter: current_quarter, classroom: classroom, status: :verified)
-    current_entry = create(:grade_entry,
-                           grade_book: current_grade_book,
-                           user: student,
-                           attendance_days: 12,
-                           math_grade: "B",
-                           reading_grade: "A")
+    current_entry = create(
+      :grade_entry,
+      grade_book: current_grade_book,
+      user: student,
+      attendance_days: 12,
+      math_grade: "B",
+      reading_grade: "A"
+    )
 
     DistributeEarnings.execute(current_grade_book)
 

--- a/test/system/admin_earnings_distribution_test.rb
+++ b/test/system/admin_earnings_distribution_test.rb
@@ -14,18 +14,22 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
 
     initial_balance = (portfolio.cash_balance * 100).to_i
 
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: 20,
-                         is_perfect_attendance: false,
-                         math_grade: "A",
-                         reading_grade: "B")
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: 20,
+      is_perfect_attendance: false,
+      math_grade: "A",
+      reading_grade: "B"
+    )
 
     assert grade_book.verified?, "Grade book should be verified before finalization"
     assert_equal 0, portfolio.portfolio_transactions.count, "Student should have no transactions initially"
@@ -75,18 +79,22 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     portfolio = student.portfolio
 
     attendance_days = 25
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: attendance_days,
-                         is_perfect_attendance: false,
-                         math_grade: nil,
-                         reading_grade: nil)
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: attendance_days,
+      is_perfect_attendance: false,
+      math_grade: nil,
+      reading_grade: nil
+    )
 
     expected_attendance_earnings = attendance_days * GradeEntry::EARNINGS_PER_DAY_ATTENDANCE
 
@@ -125,18 +133,22 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     portfolio = student.portfolio
 
     attendance_days = 30
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: attendance_days,
-                         is_perfect_attendance: true,
-                         math_grade: nil,
-                         reading_grade: nil)
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: attendance_days,
+      is_perfect_attendance: true,
+      math_grade: nil,
+      reading_grade: nil
+    )
 
     base_attendance_earnings = attendance_days * GradeEntry::EARNINGS_PER_DAY_ATTENDANCE
     perfect_bonus = GradeEntry::EARNINGS_FOR_PERFECT_ATTENDANCE
@@ -177,17 +189,21 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     student.reload
     portfolio = student.portfolio
 
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: 0,
-                         math_grade: "A",
-                         reading_grade: "A-")
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: 0,
+      math_grade: "A",
+      reading_grade: "A-"
+    )
 
     expected_math_earnings = GradeEntry::EARNINGS_FOR_A_GRADE
     expected_reading_earnings = GradeEntry::EARNINGS_FOR_A_GRADE
@@ -234,17 +250,21 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     student.reload
     portfolio = student.portfolio
 
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: 0,
-                         math_grade: "B+",
-                         reading_grade: "B")
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: 0,
+      math_grade: "B+",
+      reading_grade: "B"
+    )
 
     expected_math_earnings = GradeEntry::EARNINGS_FOR_B_GRADE
     expected_reading_earnings = GradeEntry::EARNINGS_FOR_B_GRADE
@@ -290,17 +310,21 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     portfolio = student.portfolio
 
     attendance_days = 10
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: attendance_days,
-                         math_grade: "C",
-                         reading_grade: "F")
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: attendance_days,
+      math_grade: "C",
+      reading_grade: "F"
+    )
 
     expected_attendance_only = attendance_days * GradeEntry::EARNINGS_PER_DAY_ATTENDANCE
 
@@ -344,29 +368,37 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     portfolio = student.portfolio
 
     # Previous quarter with lower grades
-    previous_grade_book = create(:grade_book,
-                                 quarter: quarter1,
-                                 classroom: classroom,
-                                 status: :completed)
+    previous_grade_book = create(
+      :grade_book,
+      quarter: quarter1,
+      classroom: classroom,
+      status: :completed
+    )
 
-    previous_entry = create(:grade_entry,
-                            grade_book: previous_grade_book,
-                            user: student,
-                            math_grade: "C",
-                            reading_grade: "B")
+    previous_entry = create(
+      :grade_entry,
+      grade_book: previous_grade_book,
+      user: student,
+      math_grade: "C",
+      reading_grade: "B"
+    )
 
     # Current quarter with improved grades
-    current_grade_book = create(:grade_book,
-                                quarter: quarter2,
-                                classroom: classroom,
-                                status: :verified)
+    current_grade_book = create(
+      :grade_book,
+      quarter: quarter2,
+      classroom: classroom,
+      status: :verified
+    )
 
-    current_entry = create(:grade_entry,
-                           grade_book: current_grade_book,
-                           user: student,
-                           attendance_days: 0,
-                           math_grade: "B",
-                           reading_grade: "A")
+    current_entry = create(
+      :grade_entry,
+      grade_book: current_grade_book,
+      user: student,
+      attendance_days: 0,
+      math_grade: "B",
+      reading_grade: "A"
+    )
 
     improvement_bonus = GradeEntry::EARNINGS_FOR_IMPROVED_GRADE
     expected_math = GradeEntry::EARNINGS_FOR_B_GRADE + improvement_bonus
@@ -415,17 +447,21 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     portfolio = student.portfolio
 
     # First quarter - no previous quarter exists
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    grade_entry = create(:grade_entry,
-                         grade_book: grade_book,
-                         user: student,
-                         attendance_days: 0,
-                         math_grade: "A",
-                         reading_grade: "A")
+    grade_entry = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: 0,
+      math_grade: "A",
+      reading_grade: "A"
+    )
 
     expected_math = GradeEntry::EARNINGS_FOR_A_GRADE
     expected_reading = GradeEntry::EARNINGS_FOR_A_GRADE
@@ -482,34 +518,42 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     student3.reload
     portfolio3 = student3.portfolio
 
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    entry1 = create(:grade_entry,
-                    grade_book: grade_book,
-                    user: student1,
-                    attendance_days: 30,
-                    is_perfect_attendance: true,
-                    math_grade: "A",
-                    reading_grade: "A")
+    entry1 = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student1,
+      attendance_days: 30,
+      is_perfect_attendance: true,
+      math_grade: "A",
+      reading_grade: "A"
+    )
 
-    entry2 = create(:grade_entry,
-                    grade_book: grade_book,
-                    user: student2,
-                    attendance_days: 20,
-                    is_perfect_attendance: false,
-                    math_grade: "B",
-                    reading_grade: "B")
+    entry2 = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student2,
+      attendance_days: 20,
+      is_perfect_attendance: false,
+      math_grade: "B",
+      reading_grade: "B"
+    )
 
-    entry3 = create(:grade_entry,
-                    grade_book: grade_book,
-                    user: student3,
-                    attendance_days: 5,
-                    is_perfect_attendance: false,
-                    math_grade: "D",
-                    reading_grade: "F")
+    entry3 = create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student3,
+      attendance_days: 5,
+      is_perfect_attendance: false,
+      math_grade: "D",
+      reading_grade: "F"
+    )
 
     student1_expected = entry1.earnings_for_attendance +
                         entry1.attendance_perfect_earnings +
@@ -565,17 +609,21 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     student.reload
     portfolio = student.portfolio
 
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :verified)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :verified
+    )
 
-    create(:grade_entry,
-           grade_book: grade_book,
-           user: student,
-           attendance_days: 15,
-           math_grade: "A",
-           reading_grade: "B")
+    create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: 15,
+      math_grade: "A",
+      reading_grade: "B"
+    )
 
     sign_in(admin)
     visit classroom_grade_book_path(classroom, grade_book)
@@ -622,17 +670,21 @@ class AdminEarningsDistributionTest < ApplicationSystemTestCase
     student = create(:student, :with_portfolio, classroom: classroom)
     student.reload
 
-    grade_book = create(:grade_book,
-                        quarter: quarter,
-                        classroom: classroom,
-                        status: :completed)
+    grade_book = create(
+      :grade_book,
+      quarter: quarter,
+      classroom: classroom,
+      status: :completed
+    )
 
-    create(:grade_entry,
-           grade_book: grade_book,
-           user: student,
-           attendance_days: 20,
-           math_grade: "A",
-           reading_grade: "A")
+    create(
+      :grade_entry,
+      grade_book: grade_book,
+      user: student,
+      attendance_days: 20,
+      math_grade: "A",
+      reading_grade: "A"
+    )
 
     assert grade_book.completed?, "Grade book should already be completed"
 


### PR DESCRIPTION
Closes #746

Adds RuboCop rules to enforce first argument on its own line for multiline method calls, as discussed and agreed by the team. Auto-fixes all existing violations.