### PR TITLE
Fix header css height

### DIFF
--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <header class="flex items-center justify-between px-6 py-4 border-b">
-    <h1 class="text-2xl font-bold">Classrooms</h1>
+    <h1 class="text-2xl font-bold py-2">Classrooms</h1>
     <% if policy(Classroom).new? %>
       <%= link_to "New classroom", new_classroom_path,
                   class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,10 +1,12 @@
 <div class="flex flex-col h-full w-full">
   <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice">
+      <%= notice %>
+    </p>
   <% end %>
 
   <header class="flex items-center justify-between px-6 py-4 border-b">
-    <h1 class="text-2xl font-bold">Transactions</h1>
+    <h1 class="text-2xl font-bold py-2">Transactions</h1>
   </header>
 
   <main class="flex-1 p-6">


### PR DESCRIPTION
# Pull Request

## Summary
Classes page has a button that is increasing the header height compared to Transactions page where there is no button.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/920

## Changes
- Make the title header the same height as the button so height is consistent between pages with button and no button.

## Screenshots (if applicable)
<img width="1260" height="120" alt="Screenshot 2026-01-26 at 22 10 43" src="https://github.com/user-attachments/assets/1f22e660-ff49-40cd-8064-22afc0d759e2" />
<img width="1260" height="108" alt="Screenshot 2026-01-26 at 22 10 49" src="https://github.com/user-attachments/assets/b032d05d-2bb0-4746-9265-7ea81534c8ca" />

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [ ] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
