### PR TITLE
Move edit classroom button

### DIFF
--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -47,20 +47,9 @@
     <div class="flex gap-8">
       <div class="flex-1">
         <%= render 'classroom_students_table', students: @classroom.users %>
-        <% if policy(@classroom).edit? %>
-          <div class="mt-8 pt-6 border-t border-gray-200">
-            <div class="flex items-center justify-between">
-              <h3 class="text-lg font-medium text-gray-900">Classroom Actions</h3>
-              <div class="flex items-center gap-3">
-                <%= render partial: "components/action_icon_button", locals: { options: { path: edit_classroom_path(@classroom), icon: "fa-pencil", title: "Edit classroom", aria_label: "Edit classroom", text_class: "text-blue-600" } } %>
-              </div>
-            </div>
-          </div>
-        <% end %>
-
       </div>
-    <!-- Temporary UI, remove when tabbed table is wired up: -->
-    <%= render "grade_books_list", grade_books: @classroom.grade_books %>
+      <!-- Temporary UI, remove when tabbed table is wired up: -->
+      <%= render "grade_books_list", grade_books: @classroom.grade_books %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Pull Request

## Summary
Moves the "Edit Class" button on the Classroom `show` view.

## Related Issue
Resolves #1028 

## Changes
- Added new button while preserving classroom's `edit` policy
- Removed old button

## Screenshots (if applicable)
| Before | After |
|--------|--------|
| <img width="1432" height="1061" alt="before" src="https://github.com/user-attachments/assets/1a449011-ae65-4dd0-9f42-5c71fab1a2ef" /> | <img width="1432" height="1061" alt="after" src="https://github.com/user-attachments/assets/67f9c249-861e-40a2-8d15-b1797b6d6937" /> | 

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
