### PR TITLE
show school year properly on the new-admin

### DIFF
--- a/app/dashboards/school_year_dashboard.rb
+++ b/app/dashboards/school_year_dashboard.rb
@@ -63,6 +63,6 @@ class SchoolYearDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(school_year)
-    "#{school_year.school.name} (#{school_year.year.name})"
+    school_year.name
   end
 end

--- a/app/models/school_year.rb
+++ b/app/models/school_year.rb
@@ -8,4 +8,8 @@ class SchoolYear < ApplicationRecord
 
   delegate :name, to: :school, prefix: :school
   delegate :name, to: :year, prefix: :year
+
+  def name
+    "#{school_name} (#{year_name})"
+  end
 end

--- a/app/views/admin_v2/classrooms/_form.html.erb
+++ b/app/views/admin_v2/classrooms/_form.html.erb
@@ -20,7 +20,7 @@
                    options_from_collection_for_select(
                      SchoolYear.joins(:school, :year).order("schools.name, years.name"),
                      :id,
-                     :to_s,
+                     :name,
                      @classroom.school_year_id
                    ),
                    label: "School Year",

--- a/test/models/school_year_test.rb
+++ b/test/models/school_year_test.rb
@@ -7,6 +7,11 @@ class SchoolYearTest < ActiveSupport::TestCase
     assert build(:school_year).validate!
   end
 
+  test "name returns school name and year name" do
+    school_year = build(:school_year)
+    assert_equal "#{school_year.school_name} (#{school_year.year_name})", school_year.name
+  end
+
   test "can be destroyed when no associations exist" do
     school_year = create(:school_year)
     assert school_year.destroy


### PR DESCRIPTION
## Summary
Show the school year properly on the admin page

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1057

## Changes
- `#{school_name} (#{year_name})` format

## Screenshots (if applicable)

http://localhost:3000/admin-new/classrooms/new

<img width="819" height="785" alt="image" src="https://github.com/user-attachments/assets/fb76f009-be24-422a-8cb3-1a13492e9a7c" />

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
