### PR TITLE
Add year selection to School pages in admin v2

### DIFF
--- a/app/controllers/admin_v2/schools_controller.rb
+++ b/app/controllers/admin_v2/schools_controller.rb
@@ -24,6 +24,7 @@ module AdminV2
 
     def new
       @school = School.new
+      set_form_data
       @breadcrumbs = [
         { label: "Schools", path: admin_v2_schools_path },
         { label: "New School" }
@@ -31,6 +32,7 @@ module AdminV2
     end
 
     def edit
+      set_form_data
       @breadcrumbs = [
         { label: "Schools", path: admin_v2_schools_path },
         { label: @school.name, path: admin_v2_school_path(@school) },
@@ -46,6 +48,7 @@ module AdminV2
       if @school.save
         redirect_to admin_v2_school_path(@school), notice: t(".notice")
       else
+        set_form_data
         @breadcrumbs = [
           { label: "Schools", path: admin_v2_schools_path },
           { label: "New School" }
@@ -62,6 +65,7 @@ module AdminV2
       if @school.update(update_params)
         redirect_to admin_v2_school_path(@school), notice: t(".notice")
       else
+        set_form_data
         @breadcrumbs = [
           { label: "Schools", path: admin_v2_schools_path },
           { label: @school.name, path: admin_v2_school_path(@school) },
@@ -80,6 +84,10 @@ module AdminV2
 
     def set_school
       @school = School.find(params[:id])
+    end
+
+    def set_form_data
+      @years = Year.ordered_by_start_year
     end
 
     def school_params

--- a/app/views/admin_v2/schools/_form.html.erb
+++ b/app/views/admin_v2/schools/_form.html.erb
@@ -8,7 +8,7 @@
                        hint: "Enter the school name",
                        placeholder: "Lincoln Elementary School" %>
 
-      <%= f.collection_check_boxes :year_ids, Year.ordered_by_start_year, :id, :name,
+      <%= f.collection_check_boxes :year_ids, @years, :id, :name,
                                    label: "Years",
                                    hint: "Select the school years this school will be active" %>
     </div>

--- a/test/controllers/admin_v2/schools_controller_test.rb
+++ b/test/controllers/admin_v2/schools_controller_test.rb
@@ -190,5 +190,14 @@ module AdminV2
 
       assert_redirected_to admin_v2_schools_path
     end
+
+    test "cannot destroy school with associated years" do
+      school = create(:school, name: "Test School")
+      school.years << create(:year, name: "2025 - 2026")
+
+      assert_no_difference("School.count") do
+        delete admin_v2_school_path(school)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
Add year checkboxes to the School new/edit forms in the admin v2 interface, allowing admins to associate schools with school years.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1056

## Changes
- Added `collection_check_boxes` for `year_ids` to the school form partial
- Updated `SchoolsController` to permit and handle `year_ids[]` in `create` and `update`
- Added `AdminV2::SchoolsControllerTest` covering index, show, new, create, edit, update, and destroy

## Screenshots (if applicable)
### Edit
<img width="1470" height="830" alt="editSchool" src="https://github.com/user-attachments/assets/135c8871-446d-47f3-8735-e969793b6c89" />
### Create
<img width="1198" height="757" alt="newSchool" src="https://github.com/user-attachments/assets/2e211cdb-edd4-4146-abca-06ed82dcafd9" />


## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- Follows the same pattern used by `TeachersController` for `classroom_ids`