### PR TITLE
Style Forgot Password page to match login page

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -12,13 +12,13 @@
 
       <div class="space-y-4">
         <%= f.email_field :email,
-              autofocus: true,
-              autocomplete: "email",
-              placeholder: "Email address",
-              class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 shadow-xs focus-visible:outline-hidden focus-visible:ring-3 focus-visible:ring-offset-2 focus-visible:border-muted" %>
+                          autofocus: true,
+                          autocomplete: "email",
+                          placeholder: "Email address",
+                          class: "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 shadow-xs focus-visible:outline-hidden focus-visible:ring-3 focus-visible:ring-offset-2 focus-visible:border-muted" %>
 
         <%= f.submit "Send me reset password instructions",
-              class: "flex w-full justify-center rounded-md bg-[#00698C] px-3 py-1.5 text-sm/6 text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 cursor-pointer" %>
+                     class: "flex w-full justify-center rounded-md bg-[#00698C] px-3 py-1.5 text-sm/6 text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 cursor-pointer" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
## Summary
Replace the unstyled default Devise view with a Tailwind layout consistent with the sign in page.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/822

## Changes
- Centered logo and heading matching login page layout
- Styled email input with matching focus ring behavior
- Teal submit button consistent with sign in button
- "Back to sign in" link

## Screenshots (if applicable)
<img width="516" height="378" alt="forgotPassword" src="https://github.com/user-attachments/assets/9601e1db-fdcb-43b2-92f8-a3e255344e8d" />

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members