### PR TITLE
Sort transaction table by date descending

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,7 +7,7 @@ class OrdersController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @orders = policy_scope(Order)
+    @orders = policy_scope(Order).order(created_at: :desc)
   end
 
   def new


### PR DESCRIPTION
## Summary
Orders on the transactions index page now show most recent first.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1051

## Changes
- `OrdersController#index`: added `.order(created_at: :desc)` to the query

## Screenshots
<img width="1255" height="455" alt="TransactionSortByDate" src="https://github.com/user-attachments/assets/1d8f9d63-5d9e-416e-9889-9668edb17b47" />

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members