### PR TITLE
Enable Trade and Invest buttons for students only

### DIFF
--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -104,10 +104,10 @@
                   <% if total_return_amount >= 0 %>+<% end %> <%= number_to_currency(total_return_amount) %>
                 </td>
                 <td class="py-3 pr-6 align-middle">
-                  <% if current_user.admin? %>
-                    <span class="inline-flex items-center justify-center rounded-full px-6 py-2 text-xs sm:text-sm font-medium shadow cursor-not-allowed" style="background-color: #a7adaf; color: #5c636a;">Trade</span>
-                  <% else %>
+                  <% if current_user.student? %>
                     <%= link_to "Trade", stocks_path, class: "inline-flex items-center justify-center rounded-full bg-sky-800 text-white px-6 py-2 text-xs sm:text-sm font-medium shadow hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 transition-colors" %>
+                  <% else %>
+                    <span class="inline-flex items-center justify-center rounded-full px-6 py-2 text-xs sm:text-sm font-medium shadow cursor-not-allowed bg-[var(--sitf-8)] text-[var(--sitf-7)]">Trade</span>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/shared/_earnings_to_invest_card.html.erb
+++ b/app/views/shared/_earnings_to_invest_card.html.erb
@@ -3,10 +3,10 @@
     <div class="flex flex-col justify-center">
       <p class="text-sm text-gray-600">My Earnings to Invest</p>
       <p class="text-2xl font-semibold leading-tight tracking-tight mt-1"><%= number_to_currency(@portfolio.cash_balance) %></p>
-      <% if current_user.admin? %>
-        <span class="mt-2 font-medium px-6 py-2.5 rounded-full shadow-sm w-fit cursor-not-allowed" style="background-color: #a7adaf; color: #5c636a;">Invest Now</span>
-      <% else %>
+      <% if current_user.student? %>
         <%= link_to "Invest Now", stocks_path, class: "mt-2 bg-[var(--sitf-secondary-teal)] hover:bg-[var(--sitf-4)] text-white font-medium px-6 py-2.5 rounded-full shadow-sm w-fit transition-colors" %>
+      <% else %>
+        <span class="mt-2 font-medium px-6 py-2.5 rounded-full shadow-sm w-fit cursor-not-allowed bg-[var(--sitf-8)] text-[var(--sitf-7)]">Invest Now</span>
       <% end %>
     </div>
 


### PR DESCRIPTION
## Summary
Trade and Invest Now buttons are only clickable by students. Admins and teachers viewing a student's portfolio see greyed-out, non-clickable buttons.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1048

## Changes
- `portfolios/show.html.erb`: Trade button renders as disabled `<span>` for non-students
- `shared/_earnings_to_invest_card.html.erb`: Invest Now button same treatment
- Uses `current_user.student?` to cover both admin and teacher roles
- Uses `bg-[var(--sitf-8)]` and `text-[var(--sitf-7)]` CSS variables as specified in the issue

## Screenshots
### Student
<img width="1198" height="715" alt="studentPortfolio" src="https://github.com/user-attachments/assets/d77d6fac-2435-4b8f-8e0e-60fc8c3c9eb0" />
### Teacher
<img width="1466" height="835" alt="teacherPortfolio" src="https://github.com/user-attachments/assets/3472499a-a6f0-411f-8117-aef6d52c6a4b" />
### Admin
<img width="1466" height="835" alt="teacherPortfolio" src="https://github.com/user-attachments/assets/c79effee-c0e6-4524-afb3-2f8471b8164a" />


## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members