### PR TITLE
ISSUE 14445 / remove empty modal

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,8 +50,5 @@
         <%= yield %>
       </main>
     <% end %>
-
-    <!-- Trading Modal -->
-    <%= render 'shared/modal' %>
   </body>
 </html>


### PR DESCRIPTION
# Pull Request

## Summary
When clicking the 'buy' or 'sell' button on the stocks index route, a double modal was appearing. This PR removes the empty modal on top. 

## Related Issue
Resolves https://github.com/CareerPlug/ats/issues/14445
(link the issue url, e.g. Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/708)

## Changes
- Remove shared modal on application partial

## Screenshots (if applicable)

BEFORE
<img width="694" height="558" alt="Screenshot 2026-03-30 at 12 00 56 PM" src="https://github.com/user-attachments/assets/221752bb-619b-452d-a9c8-0bd6055827f5" />

AFTER
<img width="1275" height="895" alt="Screenshot 2026-03-30 at 12 01 07 PM" src="https://github.com/user-attachments/assets/2ee30bd2-2cc4-4c9b-9636-103303f442e4" />
