### PR TITLE
ISSUE 1086 / add turbo modal; remove header and back

### DIFF
--- a/app/views/orders/edit.html.erb
+++ b/app/views/orders/edit.html.erb
@@ -1,9 +1,3 @@
 <turbo-frame id="modal_frame">
-  <div>
-    <h1>Editing order</h1>
-    <%= render "form", order: @order, transaction_type: @order.existing_transaction_type, shares_owned: @shares_owned %>
-    <div>
-      <%= link_to "Back to orders", orders_path %>
-    </div>
-  </div>
+  <%= render "form", order: @order, transaction_type: @order.existing_transaction_type, shares_owned: @shares_owned %>
 </turbo-frame>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -118,7 +118,7 @@
               <td class="table-body-cell table-body-cell-center">
                 <div class="flex justify-center space-x-2">
                   <% if order.pending? %>
-                    <%= link_to edit_order_path(order), class: "table-action-link", data: { testid: "edit-order-button" } do %>
+                    <%= link_to edit_order_path(order), class: "table-action-link", data: { turbo_frame: "modal_frame", testid: "edit-order-button" } do %>
                       <i class="fa fa-pencil fa-lg"></i>
                     <% end %>
                     <%= form_with url: cancel_order_path(order), method: :patch, data: { confirm: t("orders.cancel.confirm"), turbo_confirm: t("orders.cancel.confirm") } do %>


### PR DESCRIPTION
# Pull Request

## Summary
The transactions edit page shouldn't show when editing a transaction. It should instead populate a modal of type buy or sell.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1086

## Changes
- Remove unnecessary header and back link
- Add remote modal to link

## Screenshots (if applicable)
<img width="1493" height="827" alt="Screenshot 2026-03-30 at 1 19 01 PM" src="https://github.com/user-attachments/assets/deb5933e-0dac-451e-960c-b6068e9b2ee3" />

