### PR TITLE
Bug: Unable to debit/deposit funds for Students on Admin

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -144,7 +144,7 @@ module Admin
     end
 
     def transaction_params
-      params.expect(student: %i[add_fund_amount transaction_type transaction_reason transaction_description])
+      params.permit(:add_fund_amount, :transaction_type, :transaction_reason, :transaction_description)
     end
 
     def transaction_amount_cents

--- a/test/controllers/admin/students_controller_test.rb
+++ b/test/controllers/admin/students_controller_test.rb
@@ -194,12 +194,10 @@ module Admin
       student = create(:student, portfolio:)
       create(:portfolio_transaction, :deposit, portfolio:, amount_cents: 10_000)
       params = {
-        student: {
-          transaction_type: "deposit",
-          add_fund_amount: "100.50",
-          transaction_reason: "awards",
-          transaction_description: "Test deposit"
-        }
+        transaction_type: "deposit",
+        add_fund_amount: "100.50",
+        transaction_reason: "awards",
+        transaction_description: "Test deposit"
       }
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
@@ -215,12 +213,10 @@ module Admin
     test "add_transaction debit" do
       student = create(:student)
       params = {
-        student: {
-          transaction_type: "debit",
-          add_fund_amount: "50.25",
-          transaction_reason: "administrative_adjustments",
-          transaction_description: "Test debit"
-        }
+        transaction_type: "debit",
+        add_fund_amount: "50.25",
+        transaction_reason: "administrative_adjustments",
+        transaction_description: "Test debit"
       }
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
@@ -235,7 +231,7 @@ module Admin
 
     test "add_transaction invalid params" do
       student = create(:student)
-      params = { student: { transaction_type: "" } }
+      params = { transaction_type: "" }
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
 
@@ -246,6 +242,26 @@ module Admin
 
       assert_redirected_to edit_admin_student_path(student)
       assert_equal expected_error_message, flash[:alert]
+    end
+
+    test "add_transaction params are not nested under student key" do
+      student = create(:student)
+      params = {
+        student: {
+          transaction_type: "deposit",
+          add_fund_amount: "50.00",
+          transaction_reason: "awards",
+          transaction_description: "Nested params should be ignored"
+        }
+      }
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      assert_no_difference("PortfolioTransaction.count") do
+        post(add_transaction_admin_student_path(student), params:)
+      end
+
+      assert_redirected_to edit_admin_student_path(student)
     end
 
     # Import/Template tests


### PR DESCRIPTION
# Pull Request
Bug: Unable to debit/deposit funds for Students on Admin
https://github.com/rubyforgood/stocks-in-the-future/issues/1097

## Summary
Currently, when you try to submit a transaction to debit/deposit funds for a student, the result is a silent failure and a 400 server side error.

## Related Issue
Resolves 
[1097](https://github.com/rubyforgood/stocks-in-the-future/issues/1097)

## Changes
- Remove Student wrapper from params transaction.
- Update tests 

## Screenshots (if applicable)

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
- I ended up going this route because it seems like transaction is a separate model from student and this seems to make more sense from a db standpoint. I am open to other opinions but this feels right.

- On a separate note I am having reservations about the naming convention of debit/deposit. While I like the fact they both start with a D, the business student (accounting) feels like it should either be debit/credit OR withdraw/deposit. Using the term debit/credit is better from an educational standpoint if we are teaching accounting principles to students but withdraw/deposit is easier to understand for the real world. Just a thought. To be fair this is all on the admin side so its kind of moot.
