### PR TITLE
Only spawn one worked for test coverage

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,12 @@ module ActiveSupport
 
     # Use PARALLEL_WORKERS=1 if you want to change the number of workers
     # For instance, PARALLEL_WORKERS=1 bin/dc rails test
-    parallelize(workers: ENV["PARALLEL_WORKERS"]&.to_i || :number_of_processors)
+    parallel_workers = if ENV["COVERAGE"] == "true"
+                         1
+                       else
+                         ENV["PARALLEL_WORKERS"]&.to_i || :number_of_processors
+                       end
+    parallelize(workers: parallel_workers)
 
     # Add more helper methods to be used by all tests here...
     def t(...)


### PR DESCRIPTION
# Pull Request

## Summary
Coverage was showing all 0s. This change allows coverage to work again but slows tests in coverage mode. This is fine because now we can actually use coverage.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1100

## Changes
- Unparallelize tests if in coverage mode

## Screenshots (if applicable)

## Checklist
- [ ] Issue is assigned (commenting on the issue page is needed)
- [ ] Issue link added to the PR's description
- [ ] Branch created from main
- [ ] Commits are small and descriptive
- [ ] Ran linter and fixed issues
- [ ] Ran tests and all tests pass
- [ ] CI checks passing
- [ ] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
