### PR TITLE
Teacher email is now their username versus a unique username

### DIFF
--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -98,7 +98,7 @@ module Admin
     end
 
     def teacher_params
-      params.expect(teacher: [:email, :name, :username, { classroom_ids: [] }])
+      params.expect(teacher: [:email, :name, { classroom_ids: [] }])
     end
 
     def set_form_data

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -5,4 +5,16 @@ class Teacher < User
 
   has_many :teacher_classrooms, dependent: :destroy
   has_many :classrooms, through: :teacher_classrooms
+
+  before_validation :sync_username_from_email
+
+  def display_name
+    name.presence || email&.split("@")&.first || "Teacher"
+  end
+
+  private
+
+  def sync_username_from_email
+    self.username = email if email.present?
+  end
 end

--- a/app/views/admin/teachers/_form.html.erb
+++ b/app/views/admin/teachers/_form.html.erb
@@ -3,14 +3,9 @@
     <div class="px-6 py-6">
       <h3 class="text-lg font-medium text-gray-900 mb-6">Teacher Details</h3>
 
-      <%= f.text_field :username,
-                       label: "Username",
-                       hint: "Unique username for the teacher",
-                       placeholder: "johndoe" %>
-
       <%= f.text_field :email,
                        label: "Email",
-                       hint: "Email address (required for account setup)",
+                       hint: "Also used as the teacher's login username",
                        placeholder: "teacher@example.com" %>
 
       <%= f.text_field :name,

--- a/db/migrate/20260401160551_backfill_teacher_username_from_email.rb
+++ b/db/migrate/20260401160551_backfill_teacher_username_from_email.rb
@@ -1,0 +1,11 @@
+class BackfillTeacherUsernameFromEmail < ActiveRecord::Migration[8.1]
+  def up
+    User.where(type: "Teacher").find_each do |teacher|
+      teacher.update_column(:username, teacher.email) if teacher.email.present?
+    end
+  end
+
+  def down
+    # No safe way to reverse — username values before migration are unknown
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_02_204736) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_01_160551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds/partials/users.rb
+++ b/db/seeds/partials/users.rb
@@ -2,7 +2,6 @@
 teacher = User.find_or_initialize_by(email: "teacher@example.com")
 unless teacher.persisted?
   teacher.attributes = {
-    username: "Teacher",
     name: "Teacher Name",
     password: "password",
     password_confirmation: "password",

--- a/test/controllers/admin/teachers/deactivations_controller_test.rb
+++ b/test/controllers/admin/teachers/deactivations_controller_test.rb
@@ -20,7 +20,7 @@ module Admin
         end
 
         assert_redirected_to admin_teachers_path
-        assert_equal "Teacher teacher1 deactivated successfully.", flash[:notice]
+        assert_equal "Teacher teacher1@example.com deactivated successfully.", flash[:notice]
         assert @teacher1.reload.discarded?
       end
 

--- a/test/controllers/admin/teachers/reactivations_controller_test.rb
+++ b/test/controllers/admin/teachers/reactivations_controller_test.rb
@@ -22,7 +22,7 @@ module Admin
         post admin_teacher_reactivation_path(@teacher1)
 
         assert_redirected_to admin_teachers_path
-        assert_equal "Teacher teacher1 reactivated successfully.", flash[:notice]
+        assert_equal "Teacher teacher1@example.com reactivated successfully.", flash[:notice]
         assert_not @teacher1.reload.discarded?
       end
 

--- a/test/controllers/admin/teachers_controller_test.rb
+++ b/test/controllers/admin/teachers_controller_test.rb
@@ -5,8 +5,8 @@ require "test_helper"
 module Admin
   class TeachersControllerTest < ActionDispatch::IntegrationTest
     test "index" do
-      teacher1 = create(:teacher, username: "marceline")
-      teacher2 = create(:teacher, username: "lsp")
+      teacher1 = create(:teacher, email: "z@example.com")
+      teacher2 = create(:teacher, email: "a@example.com")
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
 
@@ -20,15 +20,15 @@ module Admin
     end
 
     test "index sorts by username by default" do
-      create(:teacher, username: "teacher1")
-      create(:teacher, username: "teacher2")
+      create(:teacher, email: "teacher1@example.com")
+      create(:teacher, email: "teacher2@example.com")
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
 
       get admin_teachers_path
 
       assert_response :success
-      # Default sort should be by username ascending
+      # Default sort should be by username ascending (username == email for teachers)
       assert_select "tbody tr:nth-child(1)", text: /teacher1/
       assert_select "tbody tr:nth-child(2)", text: /teacher2/
     end
@@ -235,7 +235,7 @@ module Admin
 
     test "update with invalid params" do
       teacher = create(:teacher)
-      params = { teacher: { username: "" } }
+      params = { teacher: { email: "" } }
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
 
@@ -246,7 +246,7 @@ module Admin
 
     # Hard delete (destroy) tests
     test "should permanently delete deactivated teacher" do
-      teacher = create(:teacher, username: "teacher1")
+      teacher = create(:teacher, email: "teacher1@example.com")
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)
 
@@ -257,7 +257,7 @@ module Admin
       end
 
       assert_redirected_to admin_teachers_path
-      assert_equal "Teacher teacher1 permanently deleted.", flash[:notice]
+      assert_equal "Teacher teacher1@example.com permanently deleted.", flash[:notice]
       assert_nil Teacher.with_discarded.find_by(id: teacher.id)
     end
 

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -14,10 +14,10 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "after_sign_in_path_for redirects teachers to root" do
-    create(:teacher, username: "testteacher", password: "password123")
+    create(:teacher, email: "testteacher@example.com", password: "password123")
 
     post user_session_path, params: {
-      user: { username: "testteacher", password: "password123" }
+      user: { username: "testteacher@example.com", password: "password123" }
     }
 
     assert_redirected_to root_path

--- a/test/controllers/teachers_controller_test.rb
+++ b/test/controllers/teachers_controller_test.rb
@@ -110,8 +110,7 @@ class TeachersControllerTest < ActionDispatch::IntegrationTest
 
     params = {
       teacher: {
-        email: "hello@test.com",
-        username: ""
+        email: ""
       }
     }
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
     type { "Teacher" }
     password { "Passw0rd" }
     classroom { create(:classroom) }
-    sequence(:username) { |n| "teacher_#{n}" }
     sequence(:email) { |n| "teacher_#{n}@example.com" }
   end
 end

--- a/test/models/teacher_test.rb
+++ b/test/models/teacher_test.rb
@@ -15,6 +15,27 @@ class TeacherTest < ActiveSupport::TestCase
     assert_includes teacher.errors[:email], "can't be blank"
   end
 
+  test "username is automatically set to email" do
+    teacher = create(:teacher, email: "jane@school.com")
+    assert_equal "jane@school.com", teacher.username
+  end
+
+  test "username updates when email changes" do
+    teacher = create(:teacher, email: "jane@school.com")
+    teacher.update!(email: "jane.new@school.com")
+    assert_equal "jane.new@school.com", teacher.username
+  end
+
+  test "display_name returns name field" do
+    teacher = create(:teacher, name: "Jane Smith")
+    assert_equal "Jane Smith", teacher.display_name
+  end
+
+  test "display_name falls back to email prefix when name is blank" do
+    teacher = create(:teacher, name: nil, email: "jane@school.com")
+    assert_equal "jane", teacher.display_name
+  end
+
   test "can manage students in same classroom" do
     classroom = create(:classroom)
     teacher = create(:teacher, classroom: classroom)


### PR DESCRIPTION
# Pull Request

## Summary
Teacher usernames are now associated as their email addresses. There is no longer a prompt for a username when creating a teacher. Display names for the teacher will also show the teachers full name versus the username.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/627

## Changes
- Teacher usernames are now automatically derived from their email address. When a teacher record is created or updated, the` username `field is set to match the email — admins no longer need to enter a separate username for teachers
- The teacher creation/edit form has been simplified to remove the username field; the email field hint now communicates that it doubles as the login credential
- Teacher display names now show the teacher's full name rather than their username/email
- A data migration back-fills `username = email `for any existing teacher records
- Tests have been updated throughout to reflect that teacher usernames are email addresses, and invalid-params scenarios now test against a blank email rather than a blank username