### PR TITLE
Add insufficient funds/shares validation to ExecuteOrder service

### DIFF
--- a/app/services/execute_order.rb
+++ b/app/services/execute_order.rb
@@ -62,7 +62,21 @@ class ExecuteOrder
   end
 
   def insufficient_funds?
-    portfolio.cash_balance.negative?
+    available_balance_cents = settled_balance_cents - other_pending_buy_costs
+    available_balance_cents < purchase_cost
+  end
+
+  def settled_balance_cents
+    transactions = portfolio.portfolio_transactions
+    transactions.deposits.sum(:amount_cents) +
+      transactions.credits.sum(:amount_cents) -
+      transactions.debits.sum(:amount_cents) -
+      transactions.withdrawals.sum(:amount_cents) -
+      transactions.fees.sum(:amount_cents)
+  end
+
+  def other_pending_buy_costs
+    order.user.orders.pending.buy.where.not(id: order.id).sum(&:purchase_cost)
   end
 
   def insufficient_shares?

--- a/app/services/execute_order.rb
+++ b/app/services/execute_order.rb
@@ -62,21 +62,7 @@ class ExecuteOrder
   end
 
   def insufficient_funds?
-    available_balance_cents = settled_balance_cents - other_pending_buy_costs
-    available_balance_cents < purchase_cost
-  end
-
-  def settled_balance_cents
-    transactions = portfolio.portfolio_transactions
-    transactions.deposits.sum(:amount_cents) +
-      transactions.credits.sum(:amount_cents) -
-      transactions.debits.sum(:amount_cents) -
-      transactions.withdrawals.sum(:amount_cents) -
-      transactions.fees.sum(:amount_cents)
-  end
-
-  def other_pending_buy_costs
-    order.user.orders.pending.buy.where.not(id: order.id).sum(&:purchase_cost)
+    portfolio.cash_balance.negative?
   end
 
   def insufficient_shares?

--- a/app/services/execute_order.rb
+++ b/app/services/execute_order.rb
@@ -15,6 +15,16 @@ class ExecuteOrder
   def execute
     return unless order.pending?
 
+    if order.buy? && insufficient_funds?
+      order.cancel!
+      return
+    end
+
+    if order.sell? && insufficient_shares?
+      order.cancel!
+      return
+    end
+
     ActiveRecord::Base.transaction do
       create_portfolio_transaction
       create_portfolio_stock
@@ -49,6 +59,14 @@ class ExecuteOrder
 
   def update_order_status
     order.update!(status: :completed, portfolio_stock:, portfolio_transaction:)
+  end
+
+  def insufficient_funds?
+    portfolio.cash_balance.negative?
+  end
+
+  def insufficient_shares?
+    portfolio.shares_owned(stock.id) < shares
   end
 
   def purchase_cost

--- a/test/services/execute_order_test.rb
+++ b/test/services/execute_order_test.rb
@@ -126,6 +126,37 @@ class ExecuteOrderTest < ActiveSupport::TestCase
     assert_equal [3, 5], portfolio_stocks.pluck(:shares).sort
   end
 
+  test "buy order with insufficient funds is canceled" do
+    portfolio = create(:portfolio)
+    portfolio.portfolio_transactions.create!(amount_cents: 10_000, transaction_type: :deposit)
+    stock = create(:stock, price_cents: 5000)
+    order = create(:order, :pending, :buy, shares: 1, stock: stock, user: portfolio.user)
+
+    # Simulate funds disappearing after order creation
+    portfolio.portfolio_transactions.create!(amount_cents: 9000, transaction_type: :withdrawal)
+
+    ExecuteOrder.execute(order)
+    order.reload
+
+    assert order.canceled?
+    assert_equal 0, PortfolioStock.where(portfolio: portfolio, stock: stock).count
+  end
+
+  test "sell order with insufficient shares is canceled" do
+    portfolio = create(:portfolio)
+    stock = create(:stock, price_cents: 100)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: 10, purchase_price: 100)
+    order = create(:order, :pending, :sell, shares: 5, stock: stock, user: portfolio.user)
+
+    # Simulate shares disappearing after order creation (e.g., another sell executed first)
+    create(:portfolio_stock, portfolio: portfolio, stock: stock, shares: -8, purchase_price: 100)
+
+    ExecuteOrder.execute(order)
+    order.reload
+
+    assert order.canceled?
+  end
+
   test "buy then sell orders work together correctly" do
     portfolio = create(:portfolio)
     portfolio.portfolio_transactions.create!(amount_cents: 2000, transaction_type: :deposit)


### PR DESCRIPTION
# Pull Request

## Summary
Add execution-time validation to the `ExecuteOrder` service so that buy orders with insufficient funds and sell orders with insufficient shares are canceled instead of blindly executed.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1010

## Changes
- Added `insufficient_funds?` check before executing buy orders — cancels if portfolio cash balance is negative
- Added `insufficient_shares?` check before executing sell orders — cancels if portfolio doesn't hold enough shares
- Added test for buy order cancellation when funds disappear after order creation
- Added test for sell order cancellation when shares disappear after order creation

## Screenshots (if applicable)
N/A — backend service change only

## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
This closes a gap in the order execution flow: validations only ran at order creation/update time, but portfolio state can change between creation and execution (e.g., withdrawals, other orders executing first). The `ExecuteOrder` service now validates before proceeding and cancels orders that would overdraw funds or exceed available shares.