### PR TITLE
Add portfolio earnings summary to admin student page

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -17,6 +17,8 @@ module Admin
     end
 
     def show
+      @earnings_summary = EarningsSummary.new(@student.portfolio) if @student.portfolio.present?
+
       @breadcrumbs = [
         { label: "Students", path: admin_students_path },
         { label: @student.username }

--- a/app/views/admin/students/show.html.erb
+++ b/app/views/admin/students/show.html.erb
@@ -68,9 +68,10 @@
               <div class="text-xs font-medium text-purple-600 mb-1">Total Stocks Value</div>
               <div class="text-2xl font-bold text-purple-900"><%= number_to_currency(@student.portfolio.holdings_value) %></div>
             </div>
-            <div class="bg-gray-50 p-4 rounded-lg">
+            <%= link_to portfolio_path(@student.portfolio), class: "bg-gray-50 p-4 rounded-lg block hover:bg-gray-100 transition-colors" do %>
               <div class="text-xs font-medium text-gray-600 mb-1">Portfolio ID</div>
               <div class="text-2xl font-bold text-gray-900">#<%= @student.portfolio.id %></div>
+            <% end %>
             </div>
           </div>
 

--- a/app/views/admin/students/show.html.erb
+++ b/app/views/admin/students/show.html.erb
@@ -65,8 +65,8 @@
               <div class="text-2xl font-bold text-green-900"><%= number_to_currency(@student.portfolio.total_portfolio_worth) %></div>
             </div>
             <div class="bg-purple-50 p-4 rounded-lg">
-              <div class="text-xs font-medium text-purple-600 mb-1">Total Stocks Value</div>
-              <div class="text-2xl font-bold text-purple-900"><%= number_to_currency(@student.portfolio.holdings_value) %></div>
+              <div class="text-xs font-medium text-purple-600 mb-1">Total Stocks</div>
+              <div class="text-2xl font-bold text-purple-900"><%= @student.portfolio.portfolio_stocks.sum(:shares).to_i %></div>
             </div>
             <%= link_to portfolio_path(@student.portfolio), class: "bg-gray-50 p-4 rounded-lg block hover:bg-gray-100 transition-colors" do %>
               <div class="text-xs font-medium text-gray-600 mb-1">Portfolio ID</div>

--- a/app/views/admin/students/show.html.erb
+++ b/app/views/admin/students/show.html.erb
@@ -51,7 +51,7 @@
       <% if @student.portfolio.present? %>
         <div class="mt-6 pt-6 border-t border-gray-200">
           <h3 class="text-sm font-medium text-gray-500 mb-3">Portfolio Details</h3>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
             <div class="bg-blue-50 p-4 rounded-lg">
               <div class="text-xs font-medium text-blue-600 mb-1" data-testid="cash_balance_label">
                 Cash Balance
@@ -64,10 +64,49 @@
               </div>
               <div class="text-2xl font-bold text-green-900"><%= number_to_currency(@student.portfolio.total_portfolio_worth) %></div>
             </div>
+            <div class="bg-purple-50 p-4 rounded-lg">
+              <div class="text-xs font-medium text-purple-600 mb-1">Total Stocks Value</div>
+              <div class="text-2xl font-bold text-purple-900"><%= number_to_currency(@student.portfolio.holdings_value) %></div>
+            </div>
             <div class="bg-gray-50 p-4 rounded-lg">
               <div class="text-xs font-medium text-gray-600 mb-1">Portfolio ID</div>
               <div class="text-2xl font-bold text-gray-900">#<%= @student.portfolio.id %></div>
             </div>
+          </div>
+
+          <!-- Earnings Summary -->
+          <h4 class="text-sm font-medium text-gray-700 mb-3">Earnings Summary</h4>
+          <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 rounded-lg mb-6">
+            <table class="min-w-full divide-y divide-gray-300">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
+                  <th class="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white">
+                <tr>
+                  <td class="px-3 py-2 text-sm text-gray-900">Attendance Earnings</td>
+                  <td class="px-3 py-2 text-sm text-right font-medium text-gray-900"><%= number_to_currency(@earnings_summary.attendance_earnings_cents / 100.0) %></td>
+                </tr>
+                <tr>
+                  <td class="px-3 py-2 text-sm text-gray-900">Math Earnings</td>
+                  <td class="px-3 py-2 text-sm text-right font-medium text-gray-900"><%= number_to_currency(@earnings_summary.math_earnings_cents / 100.0) %></td>
+                </tr>
+                <tr>
+                  <td class="px-3 py-2 text-sm text-gray-900">Rewards</td>
+                  <td class="px-3 py-2 text-sm text-right font-medium text-gray-900"><%= number_to_currency(@earnings_summary.awards_cents / 100.0) %></td>
+                </tr>
+                <tr class="bg-green-50">
+                  <td class="px-3 py-2 text-sm font-semibold text-gray-900">Total Earnings</td>
+                  <td class="px-3 py-2 text-sm text-right font-bold text-gray-900"><%= number_to_currency(@earnings_summary.total_earnings_cents / 100.0) %></td>
+                </tr>
+                <tr>
+                  <td class="px-3 py-2 text-sm font-medium text-red-600">Transaction Fees</td>
+                  <td class="px-3 py-2 text-sm text-right font-medium text-red-600"><%= number_to_currency(@earnings_summary.transaction_fees_cents / 100.0) %></td>
+                </tr>
+              </tbody>
+            </table>
           </div>
 
           <!-- Transactions -->

--- a/test/controllers/admin/students_controller_test.rb
+++ b/test/controllers/admin/students_controller_test.rb
@@ -76,7 +76,10 @@ module Admin
     test "show displays earnings summary" do
       student = create(:student)
       portfolio = student.portfolio
-      portfolio.portfolio_transactions.create!(amount_cents: 500, transaction_type: :deposit, reason: :attendance_earnings)
+      portfolio.portfolio_transactions.create!(
+        amount_cents: 500, transaction_type: :deposit,
+        reason: :attendance_earnings
+      )
       portfolio.portfolio_transactions.create!(amount_cents: 300, transaction_type: :deposit, reason: :math_earnings)
       portfolio.portfolio_transactions.create!(amount_cents: 200, transaction_type: :deposit, reason: :awards)
 

--- a/test/controllers/admin/students_controller_test.rb
+++ b/test/controllers/admin/students_controller_test.rb
@@ -73,6 +73,24 @@ module Admin
       )
     end
 
+    test "show displays earnings summary" do
+      student = create(:student)
+      portfolio = student.portfolio
+      portfolio.portfolio_transactions.create!(amount_cents: 500, transaction_type: :deposit, reason: :attendance_earnings)
+      portfolio.portfolio_transactions.create!(amount_cents: 300, transaction_type: :deposit, reason: :math_earnings)
+      portfolio.portfolio_transactions.create!(amount_cents: 200, transaction_type: :deposit, reason: :awards)
+
+      get admin_student_path(student)
+
+      assert_response :success
+      assert_select "h4", text: "Earnings Summary"
+      assert_select "td", text: "Attendance Earnings"
+      assert_select "td", text: "Math Earnings"
+      assert_select "td", text: "Rewards"
+      assert_select "td", text: "Total Earnings"
+      assert_select "td", text: "Transaction Fees"
+    end
+
     test "new" do
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)


### PR DESCRIPTION
# Pull Request

## Summary
Add a portfolio earnings summary section and total stocks card to the admin student show page, giving admins visibility into each student's earnings breakdown.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1112

## Changes
- Added "Total Stocks" metric card (purple) alongside existing Cash Balance, Total Portfolio Worth, and Portfolio ID cards
- Added "Earnings Summary" table showing: Attendance Earnings, Math Earnings, Rewards, Total Earnings, and Transaction Fees
- Used the existing `EarningsSummary` model to aggregate earnings by category
- Added controller test verifying the earnings summary renders correctly

## Screenshots (if applicable)
<img width="1466" height="860" alt="AdminStudent1" src="https://github.com/user-attachments/assets/a64fd23d-b76e-4c7a-8d64-5506a8db20fd" />

<img width="1463" height="883" alt="AdminStudent3" src="https://github.com/user-attachments/assets/2b817ffd-68da-44e5-bb67-45831908caa4" />



## Checklist
- [x] Issue is assigned (commenting on the issue page is needed)
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
The earnings data comes from `EarningsSummary`, which aggregates `PortfolioTransaction` deposits by reason (attendance_earnings, math_earnings, awards, transaction_fees). The UI follows the existing admin page patterns — colored metric cards for key figures and a table for the detailed breakdown.