### PR TITLE
Add sorting to status column on transactions table

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -61,6 +61,9 @@ class Order < ApplicationRecord
   scope :order_by_shares, lambda { |direction = :asc|
     reorder(shares: safe_direction(direction))
   }
+  scope :order_by_status, lambda { |direction = :asc|
+    reorder(status: safe_direction(direction))
+  }
   scope :order_by_total_cost, lambda { |direction = :asc|
     dir = safe_direction(direction)
 
@@ -91,6 +94,7 @@ class Order < ApplicationRecord
     "stock" => :order_by_stock,
     "price_per_share" => :order_by_price_per_share,
     "shares" => :order_by_shares,
+    "status" => :order_by_status,
     "total_cost" => :order_by_total_cost
   }.freeze
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -34,7 +34,7 @@
             <%= sort_link(:shares, "Shares") %>
           </th>
           <th class="table-header-cell table-header-cell-left">
-            Status
+            <%= sort_link(:status, "Status") %>
           </th>
           <th class="table-header-cell table-header-cell-left">
             Type


### PR DESCRIPTION
# Pull Request

## Summary
Make the Status column sortable on the transactions (orders) table, matching the existing sorting pattern used by all other columns.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1114

## Changes
- Added `order_by_status` scope to the Order model
- Added `"status"` entry to `SORTING_METHODS` hash
- Changed the Status column header from plain text to `sort_link(:status, "Status")`

No controller changes needed — `Order.apply_sorting` already handles the dynamic dispatch.

## Screenshots (if applicable)
<img width="1470" height="884" alt="TransactionsDefault" src="https://github.com/user-attachments/assets/9daacc05-46f9-4709-ab3f-1746c3d68051" />
<img width="1466" height="882" alt="TransactionsSorted" src="https://github.com/user-attachments/assets/b1726195-4cd5-4e82-8028-43e36926cb3c" />


## Checklist
- [x] Issue is assigned
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members