### PR TITLE
Verify add teacher flow with password reset tests

### DIFF
--- a/test/controllers/teachers_controller_test.rb
+++ b/test/controllers/teachers_controller_test.rb
@@ -104,6 +104,57 @@ class TeachersControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, teacher.classrooms.count, "no classroom should be associated"
   end
 
+  test "create sends email with password reset link" do
+    admin = create(:admin)
+    sign_in(admin)
+    ActionMailer::Base.deliveries.clear
+
+    params = {
+      teacher: {
+        email: "newteacher@example.com",
+        username: "newteacher"
+      }
+    }
+
+    post admin_teachers_path, params: params
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ["newteacher@example.com"], email.to
+    assert_match(/reset_password_token=/, email.body.encoded)
+    assert_match(/Change my password/, email.body.encoded)
+  end
+
+  test "teacher can set password via reset link from creation email" do
+    admin = create(:admin)
+    sign_in(admin)
+    ActionMailer::Base.deliveries.clear
+
+    post admin_teachers_path, params: {
+      teacher: { email: "resettest@example.com", username: "resettest" }
+    }
+
+    email = ActionMailer::Base.deliveries.last
+    token = email.body.encoded.match(/reset_password_token=([^"]+)/)[1]
+
+    sign_out(admin)
+
+    # Teacher follows the link from the email
+    get edit_user_password_path(reset_password_token: token)
+    assert_response :success
+
+    # Teacher sets a new password
+    put user_password_path, params: {
+      user: {
+        reset_password_token: token,
+        password: "newpassword123",
+        password_confirmation: "newpassword123"
+      }
+    }
+
+    teacher = Teacher.find_by!(email: "resettest@example.com")
+    assert teacher.valid_password?("newpassword123")
+  end
+
   test "create with invalid params renders unprocessable_entity and does not create teacher" do
     admin = create(:admin)
     sign_in(admin)

--- a/test/controllers/teachers_controller_test.rb
+++ b/test/controllers/teachers_controller_test.rb
@@ -107,7 +107,6 @@ class TeachersControllerTest < ActionDispatch::IntegrationTest
   test "create sends email with password reset link" do
     admin = create(:admin)
     sign_in(admin)
-    ActionMailer::Base.deliveries.clear
 
     params = {
       teacher: {
@@ -116,9 +115,12 @@ class TeachersControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    post admin_teachers_path, params: params
+    emails = capture_emails do
+      post admin_teachers_path, params: params
+    end
 
-    email = ActionMailer::Base.deliveries.last
+    assert_equal 1, emails.size
+    email = emails.first
     assert_equal ["newteacher@example.com"], email.to
     assert_match(/reset_password_token=/, email.body.encoded)
     assert_match(/Change my password/, email.body.encoded)


### PR DESCRIPTION
# Pull Request

## Summary
Add integration tests verifying the full "add a teacher" flow end-to-end: admin creates teacher → email sent with reset link → teacher follows link → sets password successfully.

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/823

## Changes
- Added test verifying the password reset email contains the correct recipient and a valid `reset_password_token` link
- Added test verifying the full flow: admin creates teacher → email is sent → teacher extracts token from email → follows the reset link (GET form loads) → submits new password (PUT) → password is updated in the database

## Screenshots (if applicable)
N/A — test-only changes

## Checklist
- [x] Issue is assigned
- [x] Issue link added to the PR's description
- [x] Branch created from main
- [x] Commits are small and descriptive
- [x] Ran linter and fixed issues
- [x] Ran tests and all tests pass
- [x] CI checks passing
- [x] Review requested from team members

## Notes
Existing tests already covered teacher creation and email delivery count. These new tests close the gap by verifying the email content and the complete password reset flow. The flow uses standard Devise `:recoverable` — `send_reset_password_instructions` generates a token, the email contains an `edit_password_url` link, and the teacher submits a new password via `Devise::PasswordsController`.