### PR TITLE
Decouple stock updates with order execution. 

### DIFF
--- a/app/jobs/order_execution_job.rb
+++ b/app/jobs/order_execution_job.rb
@@ -13,7 +13,6 @@ class OrderExecutionJob < ApplicationJob
     log_pending_orders_count(pending_orders)
 
     process_pending_orders(pending_orders) unless pending_orders.empty?
-    schedule_stock_prices_update
 
     Rails.logger.info "Order execution job completed successfully"
   rescue StandardError => e
@@ -45,13 +44,6 @@ class OrderExecutionJob < ApplicationJob
 
   def log_successful_execution(pending_orders)
     Rails.logger.info "Successfully executed #{pending_orders.count} orders"
-  end
-
-  # TODO: Remove this from OrderExecutionJob. StockPricesUpdateJob should be
-  # its own independent recurring job, not coupled to order execution.
-  def schedule_stock_prices_update
-    Rails.logger.info "Scheduling stock prices update job"
-    StockPricesUpdateJob.perform_later
   end
 
   def log_execution_error(error)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,8 +1,12 @@
 development: &default
-  # Weekdays at 1 AM EST OrderExecution runs first, then triggers StockPrices via job chaining
-  # This ensures that StockPrices aren't updated before we have executed all orders
   daily_order_execution:
     class: OrderExecutionJob
+    queue: default
+    # Every 15 minutes, every day
+    schedule: "*/15 * * * *"
+
+  daily_stock_prices_update:
+    class: StockPricesUpdateJob
     queue: default
     # Due to limitations of solid queue we need to use cron format for these schedules
     # This is Monday through Friday at 9:00 PM EST (2:00 AM UTC Tues-Sat)

--- a/test/jobs/order_execution_job_test.rb
+++ b/test/jobs/order_execution_job_test.rb
@@ -27,7 +27,6 @@ class OrderExecutionJobTest < ActiveJob::TestCase
     ExecuteOrder.expects(:execute).with(order1).once
     ExecuteOrder.expects(:execute).with(order2).once
     TransactionFeeProcessor.expects(:execute).once
-    StockPricesUpdateJob.expects(:perform_later).once
 
     OrderExecutionJob.perform_now
   end
@@ -35,7 +34,6 @@ class OrderExecutionJobTest < ActiveJob::TestCase
   test "with no pending orders" do
     ExecuteOrder.expects(:execute).never
     TransactionFeeProcessor.expects(:execute).never
-    StockPricesUpdateJob.expects(:perform_later).once
 
     OrderExecutionJob.perform_now
   end


### PR DESCRIPTION
# Pull Request

## Summary
Decouple stock updates with order execution. Also run order execution every 15 minutes for now so it doesnt have to be run manually

## Related Issue
Resolves https://github.com/rubyforgood/stocks-in-the-future/issues/1160

## Changes
- Remove Stock update from Order Transacation
- Run Stock Update job every day
- Run Order Transaction Process every 15 minutes

## Screenshots (if applicable)

## Checklist
- [ ] Issue is assigned (commenting on the issue page is needed)
- [ ] Issue link added to the PR's description
- [ ] Branch created from main
- [ ] Commits are small and descriptive
- [ ] Ran linter and fixed issues
- [ ] Ran tests and all tests pass
- [ ] CI checks passing
- [ ] Review requested from team members

## Notes
- Discuss new or non-trivial changes in [#stocks-in-the-future slack channel](https://join.slack.com/t/rubyforgood/shared_invite/zt-2k5ezv241-Ia2Iac3amxDS8CuhOr69ZA) before or during implementation.
