### PR TITLE
Add links to students and classrooms on admin pages

### DIFF
--- a/app/views/admin/classrooms/show.html.erb
+++ b/app/views/admin/classrooms/show.html.erb
@@ -32,8 +32,8 @@
           <h3 class="text-sm font-medium text-gray-500 mb-3">Students (<%= @classroom.students.count %>)</h3>
           <ul class="space-y-2">
             <% @classroom.students.limit(10).each do |student| %>
-              <li class="text-sm text-gray-900">
-                <%= student.username %>
+              <li class="text-sm">
+                <%= link_to student.username, admin_student_path(student), class: "text-blue-600 hover:text-blue-800" %>
               </li>
             <% end %>
             <% if @classroom.students.count > 10 %>

--- a/app/views/admin/school_years/show.html.erb
+++ b/app/views/admin/school_years/show.html.erb
@@ -31,8 +31,8 @@
           <h3 class="text-sm font-medium text-gray-500 mb-3">Classrooms (<%= @school_year.classrooms.count %>)</h3>
           <ul class="space-y-2">
             <% @school_year.classrooms.limit(10).each do |classroom| %>
-              <li class="text-sm text-gray-900">
-                <%= classroom.name %>
+              <li class="text-sm">
+                <%= link_to classroom.name, admin_classroom_path(classroom), class: "text-blue-600 hover:text-blue-800" %>
               </li>
             <% end %>
             <% if @school_year.classrooms.count > 10 %>

--- a/test/controllers/admin/classrooms_controller_test.rb
+++ b/test/controllers/admin/classrooms_controller_test.rb
@@ -37,6 +37,32 @@ module Admin
       assert_select "[data-testid='grades_display'] dd", text: "9th-10th"
     end
 
+    test "show links each student to their admin show page" do
+      classroom = create(:classroom)
+      student = create(:student, classroom: classroom)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get admin_classroom_path(classroom)
+
+      assert_response :success
+      assert_select "a[href=?]", admin_student_path(student), text: student.username
+    end
+
+    test "show links every listed student, not just the first" do
+      classroom = create(:classroom)
+      students = create_list(:student, 3, classroom: classroom)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get admin_classroom_path(classroom)
+
+      assert_response :success
+      students.each do |student|
+        assert_select "a[href=?]", admin_student_path(student), text: student.username
+      end
+    end
+
     test "should get new" do
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)

--- a/test/controllers/admin/school_years_controller_test.rb
+++ b/test/controllers/admin/school_years_controller_test.rb
@@ -33,6 +33,44 @@ module Admin
       assert_select "h3", "Quarters"
     end
 
+    test "show links each classroom to its admin show page" do
+      school_year = create(:school_year)
+      classroom = create(:classroom, school_year: school_year)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get admin_school_year_path(school_year)
+
+      assert_response :success
+      assert_select "a[href=?]", admin_classroom_path(classroom), text: classroom.name
+    end
+
+    test "show links every listed classroom, not just the first" do
+      school_year = create(:school_year)
+      classrooms = create_list(:classroom, 3, school_year: school_year)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get admin_school_year_path(school_year)
+
+      assert_response :success
+      classrooms.each do |classroom|
+        assert_select "a[href=?]", admin_classroom_path(classroom), text: classroom.name
+      end
+    end
+
+    test "show links archived classrooms too" do
+      school_year = create(:school_year)
+      classroom = create(:classroom, school_year: school_year, archived: true)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get admin_school_year_path(school_year)
+
+      assert_response :success
+      assert_select "a[href=?]", admin_classroom_path(classroom), text: classroom.name
+    end
+
     test "new" do
       admin = create(:admin, admin: true, classroom: nil)
       sign_in(admin)


### PR DESCRIPTION
Closes #1205 

Adding links to the SchoolYear and Classroom Index pages so we can navigate between related objects.