### PR TITLE
Let admins give a flat allotment to a classroom

### DIFF
--- a/app/controllers/grade_books_controller.rb
+++ b/app/controllers/grade_books_controller.rb
@@ -37,17 +37,28 @@ class GradeBooksController < ApplicationController
   def flat_allotment
     amount_cents = flat_allotment_amount_cents
 
-    if amount_cents.nil? || !amount_cents.positive?
-      redirect_to classroom_grade_book_path(@classroom, @grade_book), alert: t(".invalid_amount")
+    if amount_cents&.positive?
+      give_flat_allotment(amount_cents)
     else
-      paid = DistributeFlatAllotment.execute(@grade_book, amount_cents)
-      redirect_to classroom_grade_book_path(@classroom, @grade_book),
-                  notice: t(".notice", count: paid, amount: helpers.number_to_currency(amount_cents / 100.0))
+      redirect_to classroom_grade_book_path(@classroom, @grade_book), alert: t(".invalid_amount")
     end
   end
 
   private
 
+  def give_flat_allotment(amount_cents)
+    paid = DistributeFlatAllotment.execute(@grade_book, amount_cents)
+
+    redirect_to classroom_grade_book_path(@classroom, @grade_book),
+                notice: t(".notice", count: paid, amount: helpers.number_to_currency(amount_cents / 100.0))
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to classroom_grade_book_path(@classroom, @grade_book),
+                alert: t(".failed", message: e.message)
+  end
+
+  # Read directly rather than with params.require, which raises when the field is
+  # left blank. A blank or unparseable amount is a user error reported with a
+  # flash, so it has to reach the check in #flat_allotment as nil.
   def flat_allotment_amount_cents
     amount = params[:flat_allotment_amount]
     return nil if amount.blank?

--- a/app/controllers/grade_books_controller.rb
+++ b/app/controllers/grade_books_controller.rb
@@ -34,7 +34,26 @@ class GradeBooksController < ApplicationController
     end
   end
 
+  def flat_allotment
+    amount_cents = flat_allotment_amount_cents
+
+    if amount_cents.nil? || !amount_cents.positive?
+      redirect_to classroom_grade_book_path(@classroom, @grade_book), alert: t(".invalid_amount")
+    else
+      paid = DistributeFlatAllotment.execute(@grade_book, amount_cents)
+      redirect_to classroom_grade_book_path(@classroom, @grade_book),
+                  notice: t(".notice", count: paid, amount: helpers.number_to_currency(amount_cents / 100.0))
+    end
+  end
+
   private
+
+  def flat_allotment_amount_cents
+    amount = params[:flat_allotment_amount]
+    return nil if amount.blank?
+
+    (amount.to_f * 100).round
+  end
 
   def authorize_grade_book
     authorize @grade_book

--- a/app/policies/grade_book_policy.rb
+++ b/app/policies/grade_book_policy.rb
@@ -13,6 +13,10 @@ class GradeBookPolicy < ApplicationPolicy
     user.admin?
   end
 
+  def flat_allotment?
+    user.admin?
+  end
+
   private
 
   def user_is_teacher_of_classroom?

--- a/app/services/distribute_flat_allotment.rb
+++ b/app/services/distribute_flat_allotment.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Deposits the same amount into every student's portfolio in a grade book's
+# classroom. Used when a school never sends grades for a quarter, so earnings
+# cannot be calculated and every student is given a flat amount instead.
+class DistributeFlatAllotment
+  def initialize(grade_book, amount_cents)
+    @grade_book = grade_book
+    @amount_cents = amount_cents
+  end
+
+  def self.execute(...)
+    new(...).execute
+  end
+
+  # @return [Integer] how many students were paid
+  def execute
+    return 0 unless @amount_cents.to_i.positive?
+
+    ActiveRecord::Base.transaction do
+      students.each { |student| deposit(student) }.size
+    end
+  end
+
+  private
+
+  def students
+    @grade_book.classroom.students
+  end
+
+  def deposit(student)
+    student.portfolio.portfolio_transactions.create!(
+      amount_cents: @amount_cents,
+      transaction_type: :deposit,
+      reason: :administrative_adjustments,
+      description: description
+    )
+  end
+
+  def description
+    "Flat allotment for Q#{@grade_book.quarter.number}"
+  end
+end

--- a/app/services/distribute_flat_allotment.rb
+++ b/app/services/distribute_flat_allotment.rb
@@ -18,14 +18,18 @@ class DistributeFlatAllotment
     return 0 unless @amount_cents.to_i.positive?
 
     ActiveRecord::Base.transaction do
-      students.each { |student| deposit(student) }.size
+      paid = students.to_a
+      paid.each { |student| deposit(student) }
+      paid.size
     end
   end
 
   private
 
+  # Portfolios are eager loaded because every student is deposited into, which
+  # would otherwise be one extra query per student in the classroom.
   def students
-    @grade_book.classroom.students
+    @grade_book.classroom.students.includes(:portfolio)
   end
 
   def deposit(student)

--- a/app/services/distribute_flat_allotment.rb
+++ b/app/services/distribute_flat_allotment.rb
@@ -26,8 +26,6 @@ class DistributeFlatAllotment
 
   private
 
-  # Portfolios are eager loaded because every student is deposited into, which
-  # would otherwise be one extra query per student in the classroom.
   def students
     @grade_book.classroom.students.includes(:portfolio)
   end

--- a/app/views/grade_books/_flat_allotment_form.html.erb
+++ b/app/views/grade_books/_flat_allotment_form.html.erb
@@ -4,11 +4,13 @@
               class: "flex flex-wrap items-end justify-center gap-3" do |f| %>
   <div class="flex flex-col">
     <%= f.label :flat_allotment_amount, "Flat allotment per student", class: "text-sm text-gray-700 mb-1" %>
-    <%= f.number_field :flat_allotment_amount,
-                       step: "0.01",
-                       min: "0.01",
-                       placeholder: "0.00",
-                       class: "w-40 rounded-md border border-gray-300 px-3 py-2 text-sm" %>
+    <%# No min/step: the browser would block some bad amounts with its own popup
+        and let others through to the server, so every amount is validated server
+        side and reported with a flash message like the rest of the app. %>
+    <%= f.text_field :flat_allotment_amount,
+                     inputmode: "decimal",
+                     placeholder: "0.00",
+                     class: "w-40 rounded-md border border-gray-300 px-3 py-2 text-sm" %>
   </div>
 
   <%= f.submit "Give Flat Allotment",

--- a/app/views/grade_books/_flat_allotment_form.html.erb
+++ b/app/views/grade_books/_flat_allotment_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with url: flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+              method: :post,
+              data: { turbo_frame: "_top" },
+              class: "flex flex-wrap items-end justify-center gap-3" do |f| %>
+  <div class="flex flex-col">
+    <%= f.label :flat_allotment_amount, "Flat allotment per student", class: "text-sm text-gray-700 mb-1" %>
+    <%= f.number_field :flat_allotment_amount,
+                       step: "0.01",
+                       min: "0.01",
+                       placeholder: "0.00",
+                       class: "w-40 rounded-md border border-gray-300 px-3 py-2 text-sm" %>
+  </div>
+
+  <%= f.submit "Give Flat Allotment",
+               class: "tw-btn-primary",
+               data: {
+                 turbo_confirm: "Give every student in this classroom the same amount? This creates a deposit for each student and cannot be undone."
+               } %>
+<% end %>

--- a/app/views/grade_books/_flat_allotment_form.html.erb
+++ b/app/views/grade_books/_flat_allotment_form.html.erb
@@ -4,9 +4,6 @@
               class: "flex flex-wrap items-end justify-center gap-3" do |f| %>
   <div class="flex flex-col">
     <%= f.label :flat_allotment_amount, "Flat allotment per student", class: "text-sm text-gray-700 mb-1" %>
-    <%# No min/step: the browser would block some bad amounts with its own popup
-        and let others through to the server, so every amount is validated server
-        side and reported with a flash message like the rest of the app. %>
     <%= f.text_field :flat_allotment_amount,
                      inputmode: "decimal",
                      placeholder: "0.00",

--- a/app/views/grade_books/show.html.erb
+++ b/app/views/grade_books/show.html.erb
@@ -27,6 +27,13 @@
       <div class="flex flex-col items-center pt-4">
         <%= render partial: "finalize_button" %>
       </div>
+
+      <div class="flex flex-col items-center pt-6 mt-6 border-t border-gray-200">
+        <p class="text-sm text-gray-500 mb-3 text-center">
+          If this quarter's grades never arrived, give every student the same amount instead.
+        </p>
+        <%= render partial: "flat_allotment_form" %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,7 @@ en:
       incomplete: 'Cannot finalize: Some entries are incomplete.'
       notice: Grade book finalized. Funds have been distributed.
     flat_allotment:
+      failed: 'Could not give the flat allotment, so no student was paid: %{message}'
       invalid_amount: Enter an amount greater than zero to give each student.
       notice:
         one: Gave %{amount} to %{count} student.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,11 @@ en:
       already_completed: Cannot finalize because it's already completed.
       incomplete: 'Cannot finalize: Some entries are incomplete.'
       notice: Grade book finalized. Funds have been distributed.
+    flat_allotment:
+      invalid_amount: Enter an amount greater than zero to give each student.
+      notice:
+        one: Gave %{amount} to %{count} student.
+        other: Gave %{amount} to %{count} students.
   helpers:
     label:
       portfolio_transaction:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :grade_books, only: %i[show update] do
       member do
         post :finalize
+        post :flat_allotment
       end
     end
     resources :students, except: %i[index show] do

--- a/test/controllers/grade_books_controller_test.rb
+++ b/test/controllers/grade_books_controller_test.rb
@@ -217,6 +217,63 @@ class GradeBooksControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='flat_allotment_amount']"
   end
 
+  test "the amount field leaves validation to the server" do
+    # Browser constraints would reject some amounts with a native popup and let
+    # others reach the server, so the same mistake reports two different ways.
+    sign_in(create(:admin))
+
+    get classroom_grade_book_path(@classroom, @grade_book)
+
+    assert_response :success
+    assert_select "input[name='flat_allotment_amount']:not([min]):not([max]):not([step])"
+  end
+
+  test "an invalid amount renders exactly one flash message" do
+    sign_in(create(:admin))
+
+    post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+         params: { flat_allotment_amount: "0" }
+    follow_redirect!
+
+    assert_select "#alert", count: 1
+  end
+
+  test "a successful allotment renders exactly one flash message" do
+    sign_in(create(:admin))
+
+    post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+         params: { flat_allotment_amount: "2" }
+    follow_redirect!
+
+    assert_select "#notice", count: 1
+  end
+
+  test "flat allotment reports a failed deposit instead of raising" do
+    sign_in(create(:admin))
+    DistributeFlatAllotment.stubs(:execute).raises(
+      ActiveRecord::RecordInvalid.new(PortfolioTransaction.new)
+    )
+
+    assert_no_difference "PortfolioTransaction.count" do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "5" }
+    end
+
+    assert_redirected_to classroom_grade_book_path(@classroom, @grade_book)
+    assert_match(/Could not give the flat allotment/, flash[:alert])
+  end
+
+  test "a negative amount is rejected by the server, not the browser" do
+    sign_in(create(:admin))
+
+    assert_no_difference "PortfolioTransaction.count" do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "-5" }
+    end
+
+    assert_equal "Enter an amount greater than zero to give each student.", flash[:alert]
+  end
+
   test "teachers do not see the flat allotment form" do
     sign_in(@teacher)
 

--- a/test/controllers/grade_books_controller_test.rb
+++ b/test/controllers/grade_books_controller_test.rb
@@ -206,4 +206,103 @@ class GradeBooksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to classroom_grade_book_path(@classroom, @grade_book)
     assert_equal "Cannot finalize because it's already completed.", flash[:alert]
   end
+
+  test "admins see the flat allotment form" do
+    sign_in(create(:admin))
+
+    get classroom_grade_book_path(@classroom, @grade_book)
+
+    assert_response :success
+    assert_select "form[action=?]", flat_allotment_classroom_grade_book_path(@classroom, @grade_book)
+    assert_select "input[name='flat_allotment_amount']"
+  end
+
+  test "teachers do not see the flat allotment form" do
+    sign_in(@teacher)
+
+    get classroom_grade_book_path(@classroom, @grade_book)
+
+    assert_response :success
+    assert_select "form[action=?]", flat_allotment_classroom_grade_book_path(@classroom, @grade_book), count: 0
+  end
+
+  test "flat allotment deposits the same amount for every student in the classroom" do
+    other_student = create(:student, classroom: @classroom)
+    sign_in(create(:admin))
+
+    assert_difference "PortfolioTransaction.count", 2 do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "5.50" }
+    end
+
+    assert_redirected_to classroom_grade_book_path(@classroom, @grade_book)
+
+    [@student, other_student].each do |student|
+      transaction = student.portfolio.portfolio_transactions.last
+
+      assert_equal 550, transaction.amount_cents
+      assert_equal "deposit", transaction.transaction_type
+      assert_equal "administrative_adjustments", transaction.reason
+    end
+  end
+
+  test "flat allotment pays students who have no grade entry" do
+    # The whole point of the feature: grades never arrived, so there is nothing
+    # to base earnings on and possibly no grade entries at all.
+    @grade_book.grade_entries.destroy_all
+    sign_in(create(:admin))
+
+    assert_difference "PortfolioTransaction.count", 1 do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "3" }
+    end
+
+    assert_equal 300, @student.portfolio.portfolio_transactions.last.amount_cents
+  end
+
+  test "flat allotment rejects a blank amount" do
+    sign_in(create(:admin))
+
+    assert_no_difference "PortfolioTransaction.count" do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "" }
+    end
+
+    assert_equal "Enter an amount greater than zero to give each student.", flash[:alert]
+  end
+
+  test "flat allotment rejects a zero or negative amount" do
+    sign_in(create(:admin))
+
+    ["0", "-5"].each do |amount|
+      assert_no_difference "PortfolioTransaction.count" do
+        post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+             params: { flat_allotment_amount: amount }
+      end
+
+      assert_equal "Enter an amount greater than zero to give each student.", flash[:alert]
+    end
+  end
+
+  test "teachers cannot give a flat allotment" do
+    sign_in(@teacher)
+
+    assert_no_difference "PortfolioTransaction.count" do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "5" }
+    end
+
+    assert_redirected_to root_path
+  end
+
+  test "students cannot give a flat allotment" do
+    sign_in(@student)
+
+    assert_no_difference "PortfolioTransaction.count" do
+      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
+           params: { flat_allotment_amount: "5" }
+    end
+
+    assert_redirected_to @student.portfolio_path
+  end
 end

--- a/test/controllers/grade_books_controller_test.rb
+++ b/test/controllers/grade_books_controller_test.rb
@@ -351,15 +351,4 @@ class GradeBooksControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to root_path
   end
-
-  test "students cannot give a flat allotment" do
-    sign_in(@student)
-
-    assert_no_difference "PortfolioTransaction.count" do
-      post flat_allotment_classroom_grade_book_path(@classroom, @grade_book),
-           params: { flat_allotment_amount: "5" }
-    end
-
-    assert_redirected_to @student.portfolio_path
-  end
 end

--- a/test/policies/grade_book_policy_test.rb
+++ b/test/policies/grade_book_policy_test.rb
@@ -35,4 +35,11 @@ class GradeBookPolicyTest < ActiveSupport::TestCase
     refute_permit @other_teacher, @grade_book, :finalize
     refute_permit @student, @grade_book, :finalize
   end
+
+  test "flat_allotment? allows only admin, denies everyone else" do
+    assert_permit @admin, @grade_book, :flat_allotment
+    refute_permit @owner_teacher, @grade_book, :flat_allotment
+    refute_permit @other_teacher, @grade_book, :flat_allotment
+    refute_permit @student, @grade_book, :flat_allotment
+  end
 end

--- a/test/services/distribute_flat_allotment_test.rb
+++ b/test/services/distribute_flat_allotment_test.rb
@@ -64,6 +64,25 @@ class DistributeFlatAllotmentTest < ActiveSupport::TestCase
     assert_empty other_student.portfolio.portfolio_transactions
   end
 
+  test "loads every portfolio in one query rather than one per student" do
+    create_list(:student, 5, classroom: @classroom)
+
+    portfolio_selects = []
+    collector = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      portfolio_selects << sql if payload[:name] != "SCHEMA" && sql.match?(/SELECT .* FROM "portfolios"/)
+    end
+
+    ActiveSupport::Notifications.subscribed(collector, "sql.active_record") do
+      DistributeFlatAllotment.execute(@grade_book, 100)
+    end
+
+    # Without eager loading this is one SELECT per student instead of one
+    # batched SELECT covering all of them.
+    assert_equal 1, portfolio_selects.size,
+                 "expected one batched portfolio query, got #{portfolio_selects.size}"
+  end
+
   test "does not change the grade book status" do
     create(:student, classroom: @classroom)
 

--- a/test/services/distribute_flat_allotment_test.rb
+++ b/test/services/distribute_flat_allotment_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DistributeFlatAllotmentTest < ActiveSupport::TestCase
+  def setup
+    @classroom = create(:classroom)
+    @quarter = @classroom.school_year.quarters.find_by!(number: 2)
+    @grade_book = @classroom.grade_books.find_by!(quarter: @quarter)
+  end
+
+  test "deposits the amount into every student's portfolio" do
+    students = create_list(:student, 3, classroom: @classroom)
+
+    assert_difference "PortfolioTransaction.count", 3 do
+      DistributeFlatAllotment.execute(@grade_book, 750)
+    end
+
+    students.each do |student|
+      transaction = student.portfolio.portfolio_transactions.last
+
+      assert_equal 750, transaction.amount_cents
+      assert_equal "deposit", transaction.transaction_type
+      assert_equal "administrative_adjustments", transaction.reason
+      assert_equal "Flat allotment for Q2", transaction.description
+    end
+  end
+
+  test "returns the number of students paid" do
+    create_list(:student, 2, classroom: @classroom)
+
+    assert_equal 2, DistributeFlatAllotment.execute(@grade_book, 100)
+  end
+
+  test "does nothing for a zero or negative amount" do
+    create(:student, classroom: @classroom)
+
+    assert_no_difference "PortfolioTransaction.count" do
+      assert_equal 0, DistributeFlatAllotment.execute(@grade_book, 0)
+      assert_equal 0, DistributeFlatAllotment.execute(@grade_book, -500)
+    end
+  end
+
+  test "pays students regardless of whether they have a grade entry" do
+    with_entry = create(:student, classroom: @classroom)
+    without_entry = create(:student, classroom: @classroom)
+    create(:grade_entry, grade_book: @grade_book, user: with_entry)
+
+    DistributeFlatAllotment.execute(@grade_book, 250)
+
+    [with_entry, without_entry].each do |student|
+      assert_equal 250, student.portfolio.portfolio_transactions.last.amount_cents
+    end
+  end
+
+  test "does not pay students from another classroom" do
+    other_student = create(:student, classroom: create(:classroom))
+    create(:student, classroom: @classroom)
+
+    assert_difference "PortfolioTransaction.count", 1 do
+      DistributeFlatAllotment.execute(@grade_book, 100)
+    end
+
+    assert_empty other_student.portfolio.portfolio_transactions
+  end
+
+  test "does not change the grade book status" do
+    create(:student, classroom: @classroom)
+
+    assert_no_changes -> { @grade_book.reload.status } do
+      DistributeFlatAllotment.execute(@grade_book, 100)
+    end
+  end
+end


### PR DESCRIPTION
Schools sometimes never send grades for a quarter, so there is nothing to calculate earnings from. Admins handle this by crediting every student the same amount instead.

Add an admin-only form on the grade book page that deposits a given amount into every student's portfolio in the classroom. It pays the classroom's students rather than the grade book's entries, since the entries may be missing or blank in exactly the situation this is for, and it records the deposits as administrative adjustments described as a flat allotment for the quarter so they are distinguishable from earned funds.

Finalizing is left alone: this does not change the grade book's status, so it stands beside finalizing rather than replacing it.


Resolves #


