### PR TITLE
Stop generated grade levels colliding with hard coded ones

### DIFF
--- a/test/factories/grades.rb
+++ b/test/factories/grades.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
+# Grade#level is unique, and tests that care about a level hard code a real one
+# (a classroom of 9th and 10th graders, say). Counting the sequence from 1 ran it
+# straight through that range, so a test asking for level 7 failed whenever its
+# worker had already built seven grades. Sequences are per process and survive
+# the transaction rollback between tests, so whether it collided depended on the
+# seed and the parallel split. Start above any level a school would use, so a
+# generated level and a hard coded one can never meet.
+FIRST_GENERATED_GRADE_LEVEL = 100
+
 FactoryBot.define do
   factory :grade do
-    sequence(:level) { |n| n }
+    sequence(:level) { |n| FIRST_GENERATED_GRADE_LEVEL + n }
     sequence(:name)  { |n| "Grade #{n}" }
   end
 end

--- a/test/models/grade_test.rb
+++ b/test/models/grade_test.rb
@@ -73,4 +73,24 @@ class GradeTest < ActiveSupport::TestCase
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:level], "has already been taken"
   end
+
+  # Levels a school actually uses, which tests hard code when the value matters.
+  REAL_GRADE_LEVELS = (1..12)
+
+  test "the factory generates levels clear of the ones tests hard code" do
+    generated = Array.new(20) { create(:grade).level }
+    overlapping = generated.select { |level| REAL_GRADE_LEVELS.cover?(level) }
+
+    assert_empty overlapping,
+                 "generated levels must stay out of #{REAL_GRADE_LEVELS}, or a test that " \
+                 "hard codes a real level fails once its worker's sequence reaches it"
+  end
+
+  test "a hard coded real level is still available after many generated grades" do
+    Array.new(20) { create(:grade) }
+
+    REAL_GRADE_LEVELS.each do |level|
+      assert create(:grade, level: level, name: "Real grade #{level}").persisted?
+    end
+  end
 end


### PR DESCRIPTION
ClassroomsControllerTest#test_create failed intermittently in CI with "Level has already been taken" from create(:grade, level: 7).

Grade#level is unique and the factory counted its sequence from 1, straight through the range of levels a school uses. Tests that need a particular level hard code one, so a test asking for level 7 failed whenever its worker had already built seven grades. FactoryBot sequences live in the process and are not rolled back with the database between tests, so whether the counter had reached the hard coded value by then depended on the seed and on how the tests were split across workers, which is why it passed locally on sixteen workers and failed in CI on four.

Start the sequence above any level a school would use. Levels that carry meaning, such as the 9th and 10th graders behind a "9th-10th" assertion, stay as they are and can no longer be taken first.

