### PR TITLE
Let admins assign teachers from the classroom page

### DIFF
--- a/app/controllers/admin/classrooms_controller.rb
+++ b/app/controllers/admin/classrooms_controller.rb
@@ -77,7 +77,7 @@ module Admin
     end
 
     def classroom_params
-      params.expect(classroom: [:name, :trading_enabled, :school_year_id, { grade_ids: [] }])
+      params.expect(classroom: [:name, :trading_enabled, :school_year_id, { grade_ids: [], teacher_ids: [] }])
     end
   end
 end

--- a/app/form_builders/admin/form_builder.rb
+++ b/app/form_builders/admin/form_builder.rb
@@ -262,14 +262,14 @@ module Admin
           build_single_checkbox(attribute, item, value_method, text_method)
         end
 
-        @template.safe_join([build_checkbox_collection_sentinel(attribute), *items])
+        @template.safe_join([build_checkbox_collection_hidden_field(attribute), *items])
       end
     end
 
-    # Browsers send nothing for an unchecked box, so a collection with every box
-    # cleared would leave the parameter out and the association untouched. This
-    # empty value keeps the parameter present so clearing the last one sticks.
-    def build_checkbox_collection_sentinel(attribute)
+    # Prepend a hidden field so something is sent back to the server if all
+    # checkboxes are unchecked. Otherwise the parameter is omitted and the
+    # association is left untouched.
+    def build_checkbox_collection_hidden_field(attribute)
       @template.hidden_field_tag("#{object_name}[#{attribute}][]", "", id: nil, autocomplete: "off")
     end
 

--- a/app/form_builders/admin/form_builder.rb
+++ b/app/form_builders/admin/form_builder.rb
@@ -258,10 +258,19 @@ module Admin
     # Build checkbox collection items
     def build_checkbox_collection_items(attribute, collection, value_method, text_method)
       @template.content_tag(:div, class: "mt-2 space-y-2") do
-        collection.map do |item|
+        items = collection.map do |item|
           build_single_checkbox(attribute, item, value_method, text_method)
-        end.join.html_safe # rubocop:disable Rails/OutputSafety
+        end
+
+        @template.safe_join([build_checkbox_collection_sentinel(attribute), *items])
       end
+    end
+
+    # Browsers send nothing for an unchecked box, so a collection with every box
+    # cleared would leave the parameter out and the association untouched. This
+    # empty value keeps the parameter present so clearing the last one sticks.
+    def build_checkbox_collection_sentinel(attribute)
+      @template.hidden_field_tag("#{object_name}[#{attribute}][]", "", id: nil, autocomplete: "off")
     end
 
     # Build a single checkbox item

--- a/app/views/admin/classrooms/_form.html.erb
+++ b/app/views/admin/classrooms/_form.html.erb
@@ -16,6 +16,10 @@
             end
           end %>
 
+      <%= f.collection_check_boxes :teacher_ids, Teacher.kept.order(:username), :id, :display_name,
+                                   label: "Teachers",
+                                   hint: "Select the teachers assigned to this classroom" %>
+
       <%= f.select :school_year_id,
                    options_from_collection_for_select(
                      SchoolYear.joins(:school, :year).order("schools.name, years.name"),

--- a/app/views/admin/classrooms/show.html.erb
+++ b/app/views/admin/classrooms/show.html.erb
@@ -56,7 +56,7 @@
           <ul class="space-y-2">
             <% @classroom.teachers.each do |teacher| %>
               <li class="text-sm text-gray-900">
-                <%= teacher.username %>
+                <%= teacher.display_name %>
               </li>
             <% end %>
           </ul>

--- a/test/controllers/admin/classrooms_controller_test.rb
+++ b/test/controllers/admin/classrooms_controller_test.rb
@@ -131,6 +131,20 @@ module Admin
       assert_equal name, classroom.reload.name
     end
 
+    test "show names assigned teachers the same way the edit form does" do
+      teacher = create(:teacher, name: "Ada Lovelace")
+      classroom = create(:classroom)
+      teacher.classrooms << classroom
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get admin_classroom_path(classroom)
+
+      assert_response :success
+      assert_select "li", text: teacher.display_name
+      assert_select "li", text: teacher.username, count: 0
+    end
+
     test "edit lists the teachers that can be assigned" do
       teacher = create(:teacher)
       classroom = create(:classroom)

--- a/test/controllers/admin/classrooms_controller_test.rb
+++ b/test/controllers/admin/classrooms_controller_test.rb
@@ -131,6 +131,103 @@ module Admin
       assert_equal name, classroom.reload.name
     end
 
+    test "edit lists the teachers that can be assigned" do
+      teacher = create(:teacher)
+      classroom = create(:classroom)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get edit_admin_classroom_path(classroom)
+
+      assert_response :success
+      assert_select "input[type=checkbox][name='classroom[teacher_ids][]'][value=?]", teacher.id.to_s
+    end
+
+    test "edit checks the teachers already assigned to the classroom" do
+      assigned = create(:teacher)
+      unassigned = create(:teacher)
+      classroom = create(:classroom)
+      assigned.classrooms << classroom
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get edit_admin_classroom_path(classroom)
+
+      assert_response :success
+      assert_select "input[name='classroom[teacher_ids][]'][value=?][checked]", assigned.id.to_s
+      assert_select "input[name='classroom[teacher_ids][]'][value=?][checked]", unassigned.id.to_s, count: 0
+    end
+
+    test "edit does not offer discarded teachers" do
+      discarded = create(:teacher)
+      discarded.discard
+      classroom = create(:classroom)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get edit_admin_classroom_path(classroom)
+
+      assert_response :success
+      assert_select "input[name='classroom[teacher_ids][]'][value=?]", discarded.id.to_s, count: 0
+    end
+
+    test "update adds a teacher to the classroom" do
+      teacher = create(:teacher)
+      classroom = create(:classroom)
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      patch admin_classroom_path(classroom), params: { classroom: { teacher_ids: [teacher.id] } }
+
+      assert_redirected_to admin_classroom_path(classroom)
+      assert_includes classroom.reload.teachers, teacher
+    end
+
+    test "update adds a teacher without dropping the ones already assigned" do
+      existing = create(:teacher)
+      added = create(:teacher)
+      classroom = create(:classroom)
+      existing.classrooms << classroom
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      patch admin_classroom_path(classroom),
+            params: { classroom: { teacher_ids: [existing.id, added.id] } }
+
+      assert_equal [existing, added].map(&:id).sort, classroom.reload.teachers.map(&:id).sort
+    end
+
+    test "the form can clear every teacher, not just some of them" do
+      teacher = create(:teacher)
+      classroom = create(:classroom)
+      teacher.classrooms << classroom
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      get edit_admin_classroom_path(classroom)
+
+      # Unchecking every box sends nothing for the checkboxes themselves, so the
+      # form carries an empty value to keep the parameter present.
+      assert_select "input[type=hidden][name='classroom[teacher_ids][]'][value='']"
+
+      patch admin_classroom_path(classroom), params: { classroom: { teacher_ids: [""] } }
+
+      assert_empty classroom.reload.teachers
+    end
+
+    test "update removes a teacher left unchecked" do
+      kept_teacher = create(:teacher)
+      removed = create(:teacher)
+      classroom = create(:classroom)
+      [kept_teacher, removed].each { |t| t.classrooms << classroom }
+      admin = create(:admin, admin: true, classroom: nil)
+      sign_in(admin)
+
+      patch admin_classroom_path(classroom), params: { classroom: { teacher_ids: [kept_teacher.id] } }
+
+      assert_equal [kept_teacher.id], classroom.reload.teachers.map(&:id)
+    end
+
     test "update with invalid params" do
       classroom = create(:classroom)
       params = { classroom: { name: "" } }

--- a/test/controllers/admin/classrooms_controller_test.rb
+++ b/test/controllers/admin/classrooms_controller_test.rb
@@ -221,7 +221,7 @@ module Admin
       get edit_admin_classroom_path(classroom)
 
       # Unchecking every box sends nothing for the checkboxes themselves, so the
-      # form carries an empty value to keep the parameter present.
+      # form includes a hidden field with an empty value to keep the parameter present.
       assert_select "input[type=hidden][name='classroom[teacher_ids][]'][value='']"
 
       patch admin_classroom_path(classroom), params: { classroom: { teacher_ids: [""] } }


### PR DESCRIPTION
Teachers could only be attached to a classroom from the teacher's own admin page, so setting up a classroom meant editing every teacher in turn.

Add a Teachers checkbox list to the classroom form alongside Grades, offering teachers that have not been discarded and labelling them with the name the model already uses for display.

The admin form builder wrote these collections with check_box_tag, which sends nothing when a box is unchecked. Clearing the last teacher therefore left the parameter out of the request and the association untouched, so the checkbox could add but not remove. Carry the empty value that Rails' own collection_check_boxes emits, which fixes the grades, years and classrooms collections the same way.

